### PR TITLE
fix: prevent OOM by sequentially processing json logs

### DIFF
--- a/packages/cli/src/lib/claude-code.ts
+++ b/packages/cli/src/lib/claude-code.ts
@@ -104,22 +104,17 @@ function createClaudeTokenTotals(usage: ClaudeUsagePayload): DailyTokenTotals {
   };
 }
 
-async function parseClaudeFile(filePath: string) {
-  const entries: ClaudeLogEntry[] = [];
-  const lines = await readJsonLines<ClaudeRawLogEntry>(filePath);
-
-  for (const line of lines) {
+async function* parseClaudeFile(filePath: string) {
+  for await (const line of readJsonLines<ClaudeRawLogEntry>(filePath)) {
     const parsed = parseClaudeLogEntry(line);
 
     if (parsed) {
-      entries.push(parsed);
+      yield parsed;
     }
   }
-
-  return entries;
 }
 
-async function parseClaudeFiles() {
+async function getClaudeFiles() {
   const projectDirs = getClaudeProjectDirs();
   const files = (
     await Promise.all(
@@ -127,7 +122,7 @@ async function parseClaudeFiles() {
     )
   ).flat();
 
-  return Promise.all(files.map((file) => parseClaudeFile(file)));
+  return files;
 }
 
 function createUniqueHash(messageId?: string, requestId?: string) {
@@ -142,7 +137,7 @@ export async function loadClaudeRows(
   startDate: Date,
   endDate: Date,
 ): Promise<UsageSummary> {
-  const sessions = await parseClaudeFiles();
+  const files = await getClaudeFiles();
 
   const totals: DailyTotalsByDate = new Map();
   const modelTotals = new Map<string, ModelTokenTotals>();
@@ -150,8 +145,8 @@ export async function loadClaudeRows(
   const recentStart = getRecentWindowStart(endDate, 30);
   const processedHashes = new Set<string>();
 
-  for (const session of sessions) {
-    for (const entry of session) {
+  for (const file of files) {
+    for await (const entry of parseClaudeFile(file)) {
       const uniqueHash = createUniqueHash(entry.messageId, entry.requestId);
 
       if (uniqueHash && processedHashes.has(uniqueHash)) {

--- a/packages/cli/src/lib/codex.ts
+++ b/packages/cli/src/lib/codex.ts
@@ -142,38 +142,36 @@ function extractCodexModel(payload?: CodexEventPayload) {
   return undefined;
 }
 
-async function parseCodexFile(filePath: string) {
+function parseCodexFile(filePath: string) {
   return readJsonLines<CodexEventEntry>(filePath);
 }
 
-async function parseCodexFiles() {
+async function getCodexFiles() {
   const codexHome = process.env.CODEX_HOME?.trim()
     ? resolve(process.env.CODEX_HOME)
     : join(homedir(), ".codex");
 
   const sessionsDir = join(codexHome, "sessions");
 
-  const files = await listFilesRecursive(sessionsDir, ".jsonl");
-
-  return Promise.all(files.map((file) => parseCodexFile(file)));
+  return listFilesRecursive(sessionsDir, ".jsonl");
 }
 
 export async function loadCodexRows(
   start: Date,
   end: Date,
 ): Promise<UsageSummary> {
-  const sessions = await parseCodexFiles();
+  const files = await getCodexFiles();
 
   const totals: DailyTotalsByDate = new Map();
   const recentStart = getRecentWindowStart(end, 30);
   const modelTotals = new Map<string, ModelTokenTotals>();
   const recentModelTotals = new Map<string, ModelTokenTotals>();
 
-  for (const session of sessions) {
+  for (const file of files) {
     let previousTotals: CodexNormalizedUsage | null = null;
     let currentModel: string | undefined;
 
-    for (const entry of session) {
+    for await (const entry of parseCodexFile(file)) {
       const extractedModel = extractCodexModel(entry.payload);
 
       if (entry.type === "turn_context") {

--- a/packages/cli/src/lib/open-code.ts
+++ b/packages/cli/src/lib/open-code.ts
@@ -50,34 +50,37 @@ function sumOpenCodeTokens(tokens?: OpenCodeTokens): DailyTokenTotals {
 async function parseOpenCodeFile(filePath: string) {
   const content = await readFile(filePath, "utf8");
 
-  return JSON.parse(content) as OpenCodeMessage;
+  try {
+    return JSON.parse(content) as OpenCodeMessage;
+  } catch (e) {
+    return null;
+  }
 }
 
-async function parseOpenCodeFiles() {
+async function getOpenCodeFiles() {
   const baseDir = process.env.OPENCODE_DATA_DIR?.trim()
     ? resolve(process.env.OPENCODE_DATA_DIR)
     : join(homedir(), ".local", "share", "opencode");
 
   const messagesDir = join(baseDir, "storage", "message");
 
-  const files = await listFilesRecursive(messagesDir, ".json");
-
-  return Promise.all(files.map((file) => parseOpenCodeFile(file)));
+  return listFilesRecursive(messagesDir, ".json");
 }
 
 export async function loadOpenCodeRows(
   start: Date,
   end: Date,
 ): Promise<UsageSummary> {
-  const messages = await parseOpenCodeFiles();
+  const files = await getOpenCodeFiles();
   const totals: DailyTotalsByDate = new Map();
   const dedupe = new Set<string>();
   const recentStart = getRecentWindowStart(end, 30);
   const modelTotals = new Map<string, ModelTokenTotals>();
   const recentModelTotals = new Map<string, ModelTokenTotals>();
 
-  for (const message of messages) {
-    if (dedupe.has(message.id)) {
+  for (const file of files) {
+    const message = await parseOpenCodeFile(file);
+    if (!message || dedupe.has(message.id)) {
       continue;
     }
 

--- a/packages/cli/src/lib/utils.ts
+++ b/packages/cli/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { readFile, readdir } from "node:fs/promises";
+import { readFile, readdir, open } from "node:fs/promises";
 import { join } from "node:path";
 import type { DailyUsage, Insights, ModelUsage, UsageSummary } from "../interfaces";
 
@@ -156,13 +156,23 @@ export async function listFilesRecursive(rootDir: string, extension: string) {
   return files;
 }
 
-export async function readJsonLines<T>(filePath: string): Promise<T[]> {
-  const content = await readFile(filePath, "utf8");
+export async function* readJsonLines<T>(filePath: string): AsyncGenerator<T> {
+  const file = await open(filePath, "r");
 
-  return content
-    .split(/\r?\n/)
-    .filter((line) => line.trim() !== "")
-    .map((line) => JSON.parse(line.trim()) as T);
+  try {
+    for await (const line of file.readLines()) {
+      const trimmed = line.trim();
+      if (trimmed !== "") {
+        try {
+          yield JSON.parse(trimmed) as T;
+        } catch (e) {
+          // Ignore parse errors from corrupted lines
+        }
+      }
+    }
+  } finally {
+    await file.close();
+  }
 }
 
 export function getRecentWindowStart(endDate: Date, days = 30) {


### PR DESCRIPTION
This switches file processing to read sequentially rather than concurrently via Promise.all, resolving memory exhaustion (OOM) errors in V8 that occur when dealing with massive log files. It also ensures files are read line by line utilizing node:fs/promises open to stream rather than loading huge string payloads in memory all at once.