### PR TITLE
fix: bound json ingestion for provider loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,25 @@ Model names are normalized to remove a trailing date suffix like `-20251101`.
 ## Provider/data behavior
 
 - If no provider flags are passed, the CLI renders all providers with available data.
-- The CLI always prints provider availability lines (`found`/`not found`).
+- If provider flags are passed, `slopmeter` only loads those providers and only prints availability for those providers.
+- If no provider flags are passed, the CLI loads all providers and prints availability for all providers.
 - If explicit provider flags are passed and any requested provider has no data, the command exits with an error.
 - If no provider flags are passed and no provider has data, the command exits with an error.
+
+## Environment knobs
+
+- `SLOPMETER_FILE_PROCESS_CONCURRENCY`: positive integer file-processing limit for Claude Code and Codex JSONL files. Default: `4`.
+- `SLOPMETER_MAX_JSONL_RECORD_BYTES`: byte cap for Claude Code and Codex JSONL records and OpenCode JSON documents. Default: `67108864` (`64 MB`).
+
+## JSONL oversized-record behavior
+
+- Claude Code and Codex now share the same bounded JSONL record splitter and do not materialize whole files in memory.
+- Oversized Claude Code JSONL records fail the affected file with a clear error that names the file, line number, byte cap, and `SLOPMETER_MAX_JSONL_RECORD_BYTES`.
+- OpenCode JSON message files now use a bounded JSON document reader before `JSON.parse`.
+- Oversized OpenCode JSON documents fail the affected file with a clear error that names the file, byte cap, and `SLOPMETER_MAX_JSONL_RECORD_BYTES`.
+- Codex now streams JSONL records and only parses records that affect usage aggregation.
+- Oversized irrelevant Codex records are skipped and summarized with a warning after processing.
+- Oversized relevant Codex records fail the affected file with a clear error that names the file, line number, byte cap, and `SLOPMETER_MAX_JSONL_RECORD_BYTES`.
 
 ## Data locations
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -69,6 +69,8 @@ Render only Codex usage:
 npx slopmeter --codex
 ```
 
+When provider flags are present, `slopmeter` only loads those providers and only prints availability for those providers.
+
 Render a dark-theme SVG:
 
 ```bash
@@ -92,6 +94,21 @@ npx slopmeter --dark --format svg --output ./out/heatmap-dark.svg
 - If no provider flags are passed, `slopmeter` renders every provider with available data.
 - If provider flags are passed and a requested provider has no data, the command exits with an error.
 - If no provider has data, the command exits with an error.
+
+## Environment variables
+
+- `SLOPMETER_FILE_PROCESS_CONCURRENCY`: positive integer file-processing limit for Claude Code and Codex JSONL files. Default: `4`.
+- `SLOPMETER_MAX_JSONL_RECORD_BYTES`: byte cap for Claude Code and Codex JSONL records and OpenCode JSON documents. Default: `67108864` (`64 MB`).
+
+## JSONL record handling
+
+- Claude Code and Codex JSONL files are streamed through the same bounded record splitter; `slopmeter` does not materialize whole files in memory.
+- Oversized Claude Code JSONL records fail the file with a clear error that names the file, line number, byte cap, and `SLOPMETER_MAX_JSONL_RECORD_BYTES`.
+- OpenCode JSON message files are read through a bounded JSON document reader before `JSON.parse`.
+- Oversized OpenCode JSON documents fail the file with a clear error that names the file, byte cap, and `SLOPMETER_MAX_JSONL_RECORD_BYTES`.
+- Only Codex `turn_context` and `event_msg` `token_count` records are parsed for usage aggregation.
+- Oversized irrelevant Codex records are skipped and reported in a warning summary.
+- Oversized relevant Codex records fail the file with a clear error that names the file, line number, byte cap, and `SLOPMETER_MAX_JSONL_RECORD_BYTES`.
 
 ## License
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "dev": "tsx src/cli.ts",
     "build": "tsup",
+    "test": "tsup && tsx --test test/**/*.test.ts",
     "typecheck": "tsc --noEmit",
     "check": "bun run typecheck && bun run build",
     "start": "node dist/cli.js",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -247,13 +247,18 @@ async function main() {
     const requestedProviders = getRequestedProviders(values);
     const inspectedProviders =
       requestedProviders.length > 0 ? requestedProviders : providerIds;
-    const rowsByProvider = await aggregateUsage({
+    const { rowsByProvider, warnings } = await aggregateUsage({
       start,
       end,
-      providers: inspectedProviders,
+      requestedProviders,
     });
 
     spinner.stop();
+
+    for (const warning of warnings) {
+      process.stderr.write(`${warning}\n`);
+    }
+
     printProviderAvailability(rowsByProvider, inspectedProviders);
 
     const exportProviders = selectProvidersToRender(

--- a/packages/cli/src/lib/claude-code.ts
+++ b/packages/cli/src/lib/claude-code.ts
@@ -3,16 +3,20 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import type { UsageSummary } from "../interfaces";
 import {
+  DEFAULT_FILE_PROCESS_CONCURRENCY,
+  FILE_PROCESS_CONCURRENCY_ENV,
   type DailyTotalsByDate,
   type DailyTokenTotals,
   type ModelTokenTotals,
   addDailyTokenTotals,
   addModelTokenTotals,
   createUsageSummary,
-  forEachJsonLine,
+  getPositiveIntegerEnv,
   getRecentWindowStart,
   listFilesRecursive,
   normalizeModelName,
+  readJsonLines,
+  runWithConcurrency,
 } from "./utils";
 
 const CLAUDE_CONFIG_DIR_ENV = "CLAUDE_CONFIG_DIR";
@@ -133,19 +137,23 @@ export async function loadClaudeRows(
   const recentModelTotals = new Map<string, ModelTokenTotals>();
   const recentStart = getRecentWindowStart(endDate, 30);
   const processedHashes = new Set<string>();
+  const fileConcurrency = getPositiveIntegerEnv(
+    FILE_PROCESS_CONCURRENCY_ENV,
+    DEFAULT_FILE_PROCESS_CONCURRENCY,
+  );
 
-  for (const file of files) {
-    await forEachJsonLine<ClaudeRawLogEntry>(file, async (line) => {
+  await runWithConcurrency(files, fileConcurrency, async (file) => {
+    for await (const line of readJsonLines<ClaudeRawLogEntry>(file)) {
       const entry = parseClaudeLogEntry(line);
 
       if (!entry) {
-        return;
+        continue;
       }
 
       const uniqueHash = createUniqueHash(entry.messageId, entry.requestId);
 
       if (uniqueHash && processedHashes.has(uniqueHash)) {
-        return;
+        continue;
       }
 
       if (uniqueHash) {
@@ -155,13 +163,13 @@ export async function loadClaudeRows(
       const timestamp = new Date(entry.timestamp);
 
       if (timestamp < startDate || timestamp > endDate) {
-        return;
+        continue;
       }
 
       const tokenTotals = createClaudeTokenTotals(entry.usage);
 
       if (tokenTotals.total <= 0) {
-        return;
+        continue;
       }
 
       const modelName =
@@ -172,7 +180,7 @@ export async function loadClaudeRows(
       addDailyTokenTotals(totals, timestamp, tokenTotals, modelName);
 
       if (!modelName) {
-        return;
+        continue;
       }
 
       addModelTokenTotals(modelTotals, modelName, tokenTotals);
@@ -180,8 +188,8 @@ export async function loadClaudeRows(
       if (timestamp >= recentStart) {
         addModelTokenTotals(recentModelTotals, modelName, tokenTotals);
       }
-    });
-  }
+    }
+  });
 
   return createUsageSummary(
     "claude",

--- a/packages/cli/src/lib/codex.ts
+++ b/packages/cli/src/lib/codex.ts
@@ -2,17 +2,27 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import type { UsageSummary } from "../interfaces";
 import {
+  DEFAULT_MAX_JSONL_RECORD_BYTES,
+  DEFAULT_FILE_PROCESS_CONCURRENCY,
+  FILE_PROCESS_CONCURRENCY_ENV,
+  MAX_JSONL_RECORD_BYTES_ENV,
+  type JsonlRecordDecision,
   type DailyTotalsByDate,
   type DailyTokenTotals,
   type ModelTokenTotals,
   addDailyTokenTotals,
   addModelTokenTotals,
   createUsageSummary,
-  forEachJsonLine,
+  getPositiveIntegerEnv,
   getRecentWindowStart,
   listFilesRecursive,
+  mergeDailyTotalsByDate,
+  mergeModelTotals,
   normalizeModelName,
+  readJsonlRecords,
+  runWithConcurrency,
 } from "./utils";
+const CLASSIFICATION_PREFIX_BYTES = 32 * 1024;
 
 interface CodexRawUsage {
   input_tokens?: number;
@@ -52,6 +62,25 @@ interface CodexNormalizedUsage {
   reasoning_output_tokens: number;
   total_tokens: number;
 }
+
+interface CodexFileProcessingResult {
+  totals: DailyTotalsByDate;
+  modelTotals: Map<string, ModelTokenTotals>;
+  recentModelTotals: Map<string, ModelTokenTotals>;
+  skippedOversizedIrrelevantRecords: number;
+}
+
+type JsonContext =
+  | {
+      kind: "array";
+      expecting: "valueOrEnd" | "commaOrEnd";
+    }
+  | {
+      kind: "object";
+      expecting: "keyOrEnd" | "colon" | "value" | "commaOrEnd";
+      key?: string;
+      isPayloadObject: boolean;
+    };
 
 function normalizeCodexUsage(value?: CodexRawUsage) {
   if (!value) {
@@ -147,89 +176,419 @@ async function getCodexFiles() {
     ? resolve(process.env.CODEX_HOME)
     : join(homedir(), ".codex");
 
-  const sessionsDir = join(codexHome, "sessions");
+  return listFilesRecursive(join(codexHome, "sessions"), ".jsonl");
+}
 
-  const files = await listFilesRecursive(sessionsDir, ".jsonl");
+function readJsonString(source: string, start: number) {
+  if (source[start] !== '"') {
+    return null;
+  }
 
-  return files;
+  let value = "";
+  let escaped = false;
+
+  for (let index = start + 1; index < source.length; index += 1) {
+    const char = source[index];
+
+    if (escaped) {
+      value += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+
+    if (char === '"') {
+      return { value, nextIndex: index + 1 };
+    }
+
+    value += char;
+  }
+
+  return null;
+}
+
+function skipWhitespace(source: string, start: number) {
+  let index = start;
+
+  while (index < source.length && /\s/.test(source[index])) {
+    index += 1;
+  }
+
+  return index;
+}
+
+function skipPrimitive(source: string, start: number) {
+  let index = start;
+
+  while (index < source.length) {
+    const char = source[index];
+
+    if (char === "," || char === "}" || char === "]" || /\s/.test(char)) {
+      return index;
+    }
+
+    index += 1;
+  }
+
+  return source.length;
+}
+
+function classifyCodexRecord(
+  source: string,
+): JsonlRecordDecision<"turn_context" | "token_count"> {
+  const stack: JsonContext[] = [];
+  let topLevelType: string | undefined;
+
+  for (let index = 0; index < source.length; ) {
+    index = skipWhitespace(source, index);
+
+    if (index >= source.length) {
+      break;
+    }
+
+    const char = source[index];
+
+    if (stack.length === 0) {
+      if (char !== "{") {
+        return { kind: "unknown" };
+      }
+
+      stack.push({
+        kind: "object",
+        expecting: "keyOrEnd",
+        isPayloadObject: false,
+      });
+      index += 1;
+      continue;
+    }
+
+    const context = stack[stack.length - 1]!;
+
+    if (context.kind === "object") {
+      if (context.expecting === "keyOrEnd") {
+        if (char === "}") {
+          stack.pop();
+          index += 1;
+          continue;
+        }
+
+        const key = readJsonString(source, index);
+
+        if (!key) {
+          return { kind: "unknown" };
+        }
+
+        context.key = key.value;
+        context.expecting = "colon";
+        index = key.nextIndex;
+        continue;
+      }
+
+      if (context.expecting === "colon") {
+        if (char !== ":") {
+          return { kind: "unknown" };
+        }
+
+        context.expecting = "value";
+        index += 1;
+        continue;
+      }
+
+      if (context.expecting === "value") {
+        if (char === "{") {
+          stack.push({
+            kind: "object",
+            expecting: "keyOrEnd",
+            isPayloadObject: stack.length === 1 && context.key === "payload",
+          });
+          context.expecting = "commaOrEnd";
+          context.key = undefined;
+          index += 1;
+          continue;
+        }
+
+        if (char === "[") {
+          stack.push({ kind: "array", expecting: "valueOrEnd" });
+          context.expecting = "commaOrEnd";
+          context.key = undefined;
+          index += 1;
+          continue;
+        }
+
+        if (char === '"') {
+          const value = readJsonString(source, index);
+
+          if (!value) {
+            return { kind: "unknown" };
+          }
+
+          if (stack.length === 1 && context.key === "type") {
+            topLevelType = value.value;
+
+            if (value.value === "turn_context") {
+              return { kind: "keep", classification: "turn_context" };
+            }
+
+            if (value.value !== "event_msg") {
+              return { kind: "skip" };
+            }
+          }
+
+          if (context.isPayloadObject && context.key === "type") {
+            if (value.value === "token_count") {
+              return topLevelType === "event_msg"
+                ? { kind: "keep", classification: "token_count" }
+                : { kind: "unknown" };
+            }
+
+            return topLevelType === "event_msg"
+              ? { kind: "skip" }
+              : { kind: "unknown" };
+          }
+
+          context.expecting = "commaOrEnd";
+          context.key = undefined;
+          index = value.nextIndex;
+          continue;
+        }
+
+        context.expecting = "commaOrEnd";
+        context.key = undefined;
+        index = skipPrimitive(source, index);
+        continue;
+      }
+
+      {
+        if (char === ",") {
+          context.expecting = "keyOrEnd";
+          index += 1;
+          continue;
+        }
+
+        if (char === "}") {
+          stack.pop();
+          index += 1;
+          continue;
+        }
+
+        return { kind: "unknown" };
+      }
+
+      continue;
+    }
+
+    if (context.expecting === "valueOrEnd") {
+      if (char === "]") {
+        stack.pop();
+        index += 1;
+        continue;
+      }
+
+      if (char === "{") {
+        stack.push({
+          kind: "object",
+          expecting: "keyOrEnd",
+          isPayloadObject: false,
+        });
+        context.expecting = "commaOrEnd";
+        index += 1;
+        continue;
+      }
+
+      if (char === "[") {
+        stack.push({ kind: "array", expecting: "valueOrEnd" });
+        context.expecting = "commaOrEnd";
+        index += 1;
+        continue;
+      }
+
+      if (char === '"') {
+        const value = readJsonString(source, index);
+
+        if (!value) {
+          return { kind: "unknown" };
+        }
+
+        context.expecting = "commaOrEnd";
+        index = value.nextIndex;
+        continue;
+      }
+
+      context.expecting = "commaOrEnd";
+      index = skipPrimitive(source, index);
+      continue;
+    }
+
+    if (char === ",") {
+      context.expecting = "valueOrEnd";
+      index += 1;
+      continue;
+    }
+
+    if (char === "]") {
+      stack.pop();
+      index += 1;
+      continue;
+    }
+
+    return { kind: "unknown" };
+  }
+
+  if (topLevelType && topLevelType !== "event_msg") {
+    return { kind: "skip" };
+  }
+
+  return { kind: "unknown" };
+}
+
+async function processCodexFile(
+  filePath: string,
+  start: Date,
+  end: Date,
+  maxRecordBytes: number,
+): Promise<CodexFileProcessingResult> {
+  const totals: DailyTotalsByDate = new Map();
+  const recentStart = getRecentWindowStart(end, 30);
+  const modelTotals = new Map<string, ModelTokenTotals>();
+  const recentModelTotals = new Map<string, ModelTokenTotals>();
+  let previousTotals: CodexNormalizedUsage | null = null;
+  let currentModel: string | undefined;
+
+  let skippedOversizedIrrelevantRecords = 0;
+
+  for await (const record of readJsonlRecords<"turn_context" | "token_count">(
+    filePath,
+    {
+      classificationPrefixBytes: CLASSIFICATION_PREFIX_BYTES,
+      classify: classifyCodexRecord,
+      maxRecordBytes,
+      onSkippedOversizedRecord: () => {
+        skippedOversizedIrrelevantRecords += 1;
+      },
+      oversizedErrorMessage: ({ filePath, lineNumber, maxRecordBytes }) =>
+        `Relevant Codex record exceeds ${maxRecordBytes} bytes in ${filePath}:${lineNumber}. Increase ${MAX_JSONL_RECORD_BYTES_ENV} to process this file.`,
+    },
+  )) {
+    let entry: CodexEventEntry;
+
+    try {
+      entry = JSON.parse(record.rawLine) as CodexEventEntry;
+    } catch {
+      continue;
+    }
+
+    const extractedModel = extractCodexModel(entry.payload);
+
+    if (record.classification === "turn_context") {
+      currentModel = extractedModel ?? currentModel;
+      continue;
+    }
+
+    const info = entry.payload?.info;
+    const lastUsage = normalizeCodexUsage(info?.last_token_usage);
+    const totalUsage = normalizeCodexUsage(info?.total_token_usage);
+    let rawUsage = lastUsage;
+
+    if (!rawUsage && totalUsage) {
+      rawUsage = subtractCodexUsage(totalUsage, previousTotals);
+    }
+
+    if (totalUsage) {
+      previousTotals = totalUsage;
+    }
+
+    if (!rawUsage) {
+      continue;
+    }
+
+    const usage: DailyTokenTotals = {
+      input: rawUsage.input_tokens,
+      output: rawUsage.output_tokens,
+      cache: { input: rawUsage.cached_input_tokens, output: 0 },
+      total: rawUsage.total_tokens,
+    };
+
+    if (usage.total <= 0) {
+      continue;
+    }
+
+    const date = new Date(entry.timestamp);
+
+    if (date < start || date > end) {
+      continue;
+    }
+
+    const modelName = extractedModel ?? currentModel;
+    const normalizedModelName = modelName
+      ? normalizeModelName(modelName)
+      : undefined;
+
+    addDailyTokenTotals(totals, date, usage, normalizedModelName);
+
+    if (!normalizedModelName) {
+      continue;
+    }
+
+    addModelTokenTotals(modelTotals, normalizedModelName, usage);
+
+    if (date >= recentStart) {
+      addModelTokenTotals(recentModelTotals, normalizedModelName, usage);
+    }
+  }
+
+  return {
+    totals,
+    modelTotals,
+    recentModelTotals,
+    skippedOversizedIrrelevantRecords,
+  };
 }
 
 export async function loadCodexRows(
   start: Date,
   end: Date,
+  warnings: string[] = [],
 ): Promise<UsageSummary> {
   const files = await getCodexFiles();
   const totals: DailyTotalsByDate = new Map();
-  const recentStart = getRecentWindowStart(end, 30);
   const modelTotals = new Map<string, ModelTokenTotals>();
   const recentModelTotals = new Map<string, ModelTokenTotals>();
+  const maxRecordBytes = getPositiveIntegerEnv(
+    MAX_JSONL_RECORD_BYTES_ENV,
+    DEFAULT_MAX_JSONL_RECORD_BYTES,
+  );
+  const fileConcurrency = getPositiveIntegerEnv(
+    FILE_PROCESS_CONCURRENCY_ENV,
+    DEFAULT_FILE_PROCESS_CONCURRENCY,
+  );
+  const results = new Array<CodexFileProcessingResult>(files.length);
 
-  for (const file of files) {
-    let previousTotals: CodexNormalizedUsage | null = null;
-    let currentModel: string | undefined;
+  await runWithConcurrency(files, fileConcurrency, async (file, index) => {
+    results[index] = await processCodexFile(file, start, end, maxRecordBytes);
+  });
 
-    await forEachJsonLine<CodexEventEntry>(file, async (entry) => {
-      const extractedModel = extractCodexModel(entry.payload);
+  let skippedOversizedIrrelevantRecords = 0;
+  let skippedFiles = 0;
 
-      if (entry.type === "turn_context") {
-        currentModel = extractedModel ?? currentModel;
+  for (const result of results) {
+    mergeDailyTotalsByDate(totals, result.totals);
+    mergeModelTotals(modelTotals, result.modelTotals);
+    mergeModelTotals(recentModelTotals, result.recentModelTotals);
 
-        return;
-      }
+    if (result.skippedOversizedIrrelevantRecords > 0) {
+      skippedOversizedIrrelevantRecords += result.skippedOversizedIrrelevantRecords;
+      skippedFiles += 1;
+    }
+  }
 
-      if (entry.type !== "event_msg" || entry.payload?.type !== "token_count") {
-        return;
-      }
-
-      const info = entry.payload.info;
-      const lastUsage = normalizeCodexUsage(info?.last_token_usage);
-      const totalUsage = normalizeCodexUsage(info?.total_token_usage);
-      let rawUsage = lastUsage;
-
-      if (!rawUsage && totalUsage) {
-        rawUsage = subtractCodexUsage(totalUsage, previousTotals);
-      }
-
-      if (totalUsage) {
-        previousTotals = totalUsage;
-      }
-
-      if (!rawUsage) {
-        return;
-      }
-
-      const usage: DailyTokenTotals = {
-        input: rawUsage.input_tokens,
-        output: rawUsage.output_tokens,
-        cache: { input: rawUsage.cached_input_tokens, output: 0 },
-        total: rawUsage.total_tokens,
-      };
-
-      if (usage.total <= 0) {
-        return;
-      }
-
-      const date = new Date(entry.timestamp);
-
-      if (date < start || date > end) {
-        return;
-      }
-
-      const modelName = extractedModel ?? currentModel;
-      const normalizedModelName = modelName
-        ? normalizeModelName(modelName)
-        : undefined;
-
-      addDailyTokenTotals(totals, date, usage, normalizedModelName);
-
-      if (normalizedModelName) {
-        addModelTokenTotals(modelTotals, normalizedModelName, usage);
-
-        if (date >= recentStart) {
-          addModelTokenTotals(recentModelTotals, normalizedModelName, usage);
-        }
-      }
-    });
+  if (skippedOversizedIrrelevantRecords > 0) {
+    warnings.push(
+      `Skipped ${skippedOversizedIrrelevantRecords} oversized irrelevant Codex record(s) across ${skippedFiles} file(s); usage totals exclude those records. Relevant oversized records fail the file. Override ${MAX_JSONL_RECORD_BYTES_ENV} to raise the cap.`,
+    );
   }
 
   return createUsageSummary("codex", totals, modelTotals, recentModelTotals, end);

--- a/packages/cli/src/lib/open-code.ts
+++ b/packages/cli/src/lib/open-code.ts
@@ -1,4 +1,3 @@
-import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import type { UsageSummary } from "../interfaces";
@@ -12,6 +11,7 @@ import {
   getRecentWindowStart,
   listFilesRecursive,
   normalizeModelName,
+  readJsonDocument,
 } from "./utils";
 
 interface OpenCodeTokenCache {
@@ -48,9 +48,7 @@ function sumOpenCodeTokens(tokens?: OpenCodeTokens): DailyTokenTotals {
 }
 
 async function parseOpenCodeFile(filePath: string) {
-  const content = await readFile(filePath, "utf8");
-
-  return JSON.parse(content) as OpenCodeMessage;
+  return readJsonDocument<OpenCodeMessage>(filePath);
 }
 
 async function getOpenCodeFiles() {

--- a/packages/cli/src/lib/utils.ts
+++ b/packages/cli/src/lib/utils.ts
@@ -1,7 +1,6 @@
 import { createReadStream } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
-import { createInterface } from "node:readline";
 import type { DailyUsage, Insights, ModelUsage, UsageSummary } from "../interfaces";
 
 export function formatLocalDate(date: Date) {
@@ -34,6 +33,58 @@ interface TokenTotals {
 export type DailyTotalsByDate = Map<string, TokenTotals>;
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export const DEFAULT_FILE_PROCESS_CONCURRENCY = 4;
+export const FILE_PROCESS_CONCURRENCY_ENV =
+  "SLOPMETER_FILE_PROCESS_CONCURRENCY";
+export const MAX_JSONL_RECORD_BYTES_ENV = "SLOPMETER_MAX_JSONL_RECORD_BYTES";
+export const DEFAULT_MAX_JSONL_RECORD_BYTES = 64 * 1024 * 1024;
+
+export interface JsonlRecord<TClassification = void> {
+  lineNumber: number;
+  rawLine: string;
+  byteLength: number;
+  classification: TClassification;
+}
+
+export type JsonlRecordDecision<TClassification> =
+  | { kind: "keep"; classification: TClassification }
+  | { kind: "skip" }
+  | { kind: "unknown" };
+
+interface ReadJsonlRecordsOptions<TClassification> {
+  classificationPrefixBytes?: number;
+  classify?: (prefix: string) => JsonlRecordDecision<TClassification>;
+  maxRecordBytes?: number;
+  onSkippedOversizedRecord?: (record: {
+    lineNumber: number;
+    byteLength: number;
+  }) => void;
+  oversizedErrorMessage?: (record: {
+    filePath: string;
+    lineNumber: number;
+    maxRecordBytes: number;
+    envVarName: string;
+  }) => string;
+}
+
+interface ReadJsonDocumentOptions {
+  maxBytes?: number;
+  oversizedErrorMessage?: (record: {
+    filePath: string;
+    maxBytes: number;
+    envVarName: string;
+  }) => string;
+}
+
+interface ParseJsonTextOptions {
+  maxBytes?: number;
+  oversizedErrorMessage?: (record: {
+    sourceLabel: string;
+    maxBytes: number;
+    envVarName: string;
+  }) => string;
+}
 
 function cloneTokenTotals(
   totals: DailyTokenTotals | ModelTokenTotals,
@@ -100,6 +151,44 @@ export function addDailyTokenTotals(
   }
 }
 
+export function mergeDailyTotalsByDate(
+  target: DailyTotalsByDate,
+  source: DailyTotalsByDate,
+) {
+  for (const [dateKey, sourceTotals] of source.entries()) {
+    const existing = target.get(dateKey);
+
+    if (!existing) {
+      const models = new Map<string, ModelTokenTotals>();
+
+      for (const [modelName, totals] of sourceTotals.models.entries()) {
+        models.set(modelName, cloneTokenTotals(totals));
+      }
+
+      target.set(dateKey, {
+        tokens: cloneTokenTotals(sourceTotals.tokens),
+        models,
+      });
+      continue;
+    }
+
+    mergeTokenTotals(existing.tokens, sourceTotals.tokens);
+
+    for (const [modelName, totals] of sourceTotals.models.entries()) {
+      addModelTokenTotals(existing.models, modelName, totals);
+    }
+  }
+}
+
+export function mergeModelTotals(
+  target: Map<string, ModelTokenTotals>,
+  source: Map<string, ModelTokenTotals>,
+) {
+  for (const [modelName, totals] of source.entries()) {
+    addModelTokenTotals(target, modelName, totals);
+  }
+}
+
 export function totalsToRows(totals: DailyTotalsByDate): DailyUsage[] {
   return [...totals.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
@@ -155,31 +244,375 @@ export async function listFilesRecursive(rootDir: string, extension: string) {
     }
   }
 
-  return files;
+  return files.sort((left, right) => left.localeCompare(right));
 }
 
-export async function forEachJsonLine<T>(
+function defaultOversizedJsonlRecordMessage({
+  filePath,
+  lineNumber,
+  maxRecordBytes,
+  envVarName,
+}: {
+  filePath: string;
+  lineNumber: number;
+  maxRecordBytes: number;
+  envVarName: string;
+}) {
+  return `JSONL record exceeds ${maxRecordBytes} bytes in ${filePath}:${lineNumber}. Increase ${envVarName} to process this file.`;
+}
+
+function defaultOversizedJsonDocumentMessage({
+  filePath,
+  maxBytes,
+  envVarName,
+}: {
+  filePath: string;
+  maxBytes: number;
+  envVarName: string;
+}) {
+  return `JSON document exceeds ${maxBytes} bytes in ${filePath}. Increase ${envVarName} to process this file.`;
+}
+
+function defaultOversizedJsonTextMessage({
+  sourceLabel,
+  maxBytes,
+  envVarName,
+}: {
+  sourceLabel: string;
+  maxBytes: number;
+  envVarName: string;
+}) {
+  return `JSON payload exceeds ${maxBytes} bytes in ${sourceLabel}. Increase ${envVarName} to process this payload.`;
+}
+
+function keepAllJsonlRecords<TClassification>(): JsonlRecordDecision<TClassification> {
+  return { kind: "keep", classification: undefined as TClassification };
+}
+
+export async function* readJsonlRecords<TClassification = void>(
   filePath: string,
-  onLine: (value: T) => void | Promise<void>,
-) {
-  const readline = createInterface({
-    input: createReadStream(filePath, { encoding: "utf8" }),
-    crlfDelay: Number.POSITIVE_INFINITY,
-  });
+  options: ReadJsonlRecordsOptions<TClassification> = {},
+): AsyncGenerator<JsonlRecord<TClassification>> {
+  const maxRecordBytes =
+    options.maxRecordBytes ??
+    getPositiveIntegerEnv(
+      MAX_JSONL_RECORD_BYTES_ENV,
+      DEFAULT_MAX_JSONL_RECORD_BYTES,
+    );
+  const classificationPrefixBytes =
+    options.classificationPrefixBytes ?? maxRecordBytes;
+  const classify = options.classify ?? keepAllJsonlRecords<TClassification>;
+  const oversizedErrorMessage =
+    options.oversizedErrorMessage ?? defaultOversizedJsonlRecordMessage;
+  const stream = createReadStream(filePath);
+  let lineNumber = 0;
+  let lineBytesSeen = 0;
+  let retainedBytes = 0;
+  let prefixBytes = 0;
+  let exceededLimit = false;
+  let decision: JsonlRecordDecision<TClassification> = { kind: "unknown" };
+  let prefixChunks: Buffer[] = [];
+  let retainedChunks: Buffer[] = [];
 
-  try {
-    for await (const line of readline) {
-      const trimmed = line.trim();
+  const resetRecord = () => {
+    lineBytesSeen = 0;
+    retainedBytes = 0;
+    prefixBytes = 0;
+    exceededLimit = false;
+    decision = { kind: "unknown" };
+    prefixChunks = [];
+    retainedChunks = [];
+  };
 
-      if (trimmed === "") {
+  const maybeClassify = () => {
+    if (decision.kind !== "unknown" || prefixBytes === 0) {
+      return;
+    }
+
+    decision = classify(Buffer.concat(prefixChunks, prefixBytes).toString("utf8"));
+
+    if (decision.kind === "skip") {
+      retainedChunks = [];
+      retainedBytes = 0;
+    }
+  };
+
+  const appendSegment = (segment: Buffer) => {
+    if (segment.length === 0) {
+      return;
+    }
+
+    lineBytesSeen += segment.length;
+
+    if (prefixBytes < classificationPrefixBytes) {
+      const prefixSegment = segment.subarray(
+        0,
+        Math.min(segment.length, classificationPrefixBytes - prefixBytes),
+      );
+
+      prefixChunks.push(prefixSegment);
+      prefixBytes += prefixSegment.length;
+      maybeClassify();
+    }
+
+    if (decision.kind === "skip") {
+      return;
+    }
+
+    const remainingBytes = maxRecordBytes - retainedBytes;
+
+    if (remainingBytes > 0) {
+      const retainedSegment = segment.subarray(
+        0,
+        Math.min(segment.length, remainingBytes),
+      );
+
+      if (retainedSegment.length > 0) {
+        retainedChunks.push(retainedSegment);
+        retainedBytes += retainedSegment.length;
+      }
+    }
+
+    if (segment.length > remainingBytes) {
+      exceededLimit = true;
+    }
+  };
+
+  const resolveDecision = () => {
+    if (decision.kind !== "unknown") {
+      return decision;
+    }
+
+    const candidate =
+      exceededLimit || retainedBytes === 0
+        ? Buffer.concat(prefixChunks, prefixBytes).toString("utf8")
+        : Buffer.concat(retainedChunks, retainedBytes).toString("utf8");
+
+    return classify(candidate);
+  };
+
+  const finalizeRecord = () => {
+    lineNumber += 1;
+
+    if (lineBytesSeen === 0 && !exceededLimit) {
+      resetRecord();
+
+      return null;
+    }
+
+    const resolvedDecision = resolveDecision();
+
+    if (resolvedDecision.kind === "skip") {
+      if (lineBytesSeen > maxRecordBytes) {
+        options.onSkippedOversizedRecord?.({
+          lineNumber,
+          byteLength: lineBytesSeen,
+        });
+      }
+
+      resetRecord();
+
+      return null;
+    }
+
+    if (resolvedDecision.kind === "unknown") {
+      resetRecord();
+
+      return null;
+    }
+
+    if (lineBytesSeen > maxRecordBytes || exceededLimit) {
+      throw new Error(
+        oversizedErrorMessage({
+          filePath,
+          lineNumber,
+          maxRecordBytes,
+          envVarName: MAX_JSONL_RECORD_BYTES_ENV,
+        }),
+      );
+    }
+
+    const rawLine = Buffer.concat(retainedChunks, retainedBytes)
+      .toString("utf8")
+      .trim();
+
+    if (rawLine === "") {
+      resetRecord();
+
+      return null;
+    }
+
+    const record: JsonlRecord<TClassification> = {
+      lineNumber,
+      rawLine,
+      byteLength: lineBytesSeen,
+      classification: resolvedDecision.classification,
+    };
+
+    resetRecord();
+
+    return record;
+  };
+
+  for await (const chunk of stream) {
+    let start = 0;
+
+    for (let index = 0; index < chunk.length; index += 1) {
+      if (chunk[index] !== 0x0a) {
         continue;
       }
 
-      await onLine(JSON.parse(trimmed) as T);
+      appendSegment(chunk.subarray(start, index));
+      const record = finalizeRecord();
+
+      if (record) {
+        yield record;
+      }
+
+      start = index + 1;
     }
-  } finally {
-    readline.close();
+
+    appendSegment(chunk.subarray(start));
   }
+
+  if (lineBytesSeen > 0) {
+    const record = finalizeRecord();
+
+    if (record) {
+      yield record;
+    }
+  }
+}
+
+export async function* readJsonLines<T>(filePath: string): AsyncGenerator<T> {
+  for await (const record of readJsonlRecords(filePath)) {
+    try {
+      yield JSON.parse(record.rawLine) as T;
+    } catch {
+      // Preserve existing behavior for malformed JSONL records.
+    }
+  }
+}
+
+export async function readJsonDocument<T>(
+  filePath: string,
+  options: ReadJsonDocumentOptions = {},
+) {
+  const maxBytes =
+    options.maxBytes ??
+    getPositiveIntegerEnv(
+      MAX_JSONL_RECORD_BYTES_ENV,
+      DEFAULT_MAX_JSONL_RECORD_BYTES,
+    );
+  const oversizedErrorMessage =
+    options.oversizedErrorMessage ?? defaultOversizedJsonDocumentMessage;
+  const stream = createReadStream(filePath);
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+
+  for await (const chunk of stream) {
+    totalBytes += chunk.length;
+
+    if (totalBytes > maxBytes) {
+      stream.destroy();
+
+      throw new Error(
+        oversizedErrorMessage({
+          filePath,
+          maxBytes,
+          envVarName: MAX_JSONL_RECORD_BYTES_ENV,
+        }),
+      );
+    }
+
+    chunks.push(chunk);
+  }
+
+  return parseJsonTextWithLimit<T>(
+    Buffer.concat(chunks, totalBytes).toString("utf8"),
+    filePath,
+    {
+      maxBytes,
+      oversizedErrorMessage: ({ sourceLabel, maxBytes, envVarName }) =>
+        oversizedErrorMessage({
+          filePath: sourceLabel,
+          maxBytes,
+          envVarName,
+        }),
+    },
+  );
+}
+
+export function parseJsonTextWithLimit<T>(
+  content: string,
+  sourceLabel: string,
+  options: ParseJsonTextOptions = {},
+) {
+  const maxBytes =
+    options.maxBytes ??
+    getPositiveIntegerEnv(
+      MAX_JSONL_RECORD_BYTES_ENV,
+      DEFAULT_MAX_JSONL_RECORD_BYTES,
+    );
+  const oversizedErrorMessage =
+    options.oversizedErrorMessage ?? defaultOversizedJsonTextMessage;
+
+  if (Buffer.byteLength(content, "utf8") > maxBytes) {
+    throw new Error(
+      oversizedErrorMessage({
+        sourceLabel,
+        maxBytes,
+        envVarName: MAX_JSONL_RECORD_BYTES_ENV,
+      }),
+    );
+  }
+
+  return JSON.parse(content) as T;
+}
+
+export function getPositiveIntegerEnv(name: string, fallback: number) {
+  const raw = process.env[name]?.trim();
+
+  if (!raw) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+export async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<void>,
+) {
+  if (items.length === 0) {
+    return;
+  }
+
+  const limit = Math.max(1, Math.min(concurrency, items.length));
+  let nextIndex = 0;
+
+  await Promise.all(
+    Array.from({ length: limit }, async () => {
+      for (;;) {
+        const currentIndex = nextIndex;
+
+        nextIndex += 1;
+
+        if (currentIndex >= items.length) {
+          return;
+        }
+
+        await worker(items[currentIndex], currentIndex);
+      }
+    }),
+  );
 }
 
 export function getRecentWindowStart(endDate: Date, days = 30) {

--- a/packages/cli/src/providers.ts
+++ b/packages/cli/src/providers.ts
@@ -14,31 +14,38 @@ export { providerIds, providerStatusLabel, type ProviderId };
 interface AggregateUsageOptions {
   start: Date;
   end: Date;
-  providers?: ProviderId[];
+  requestedProviders?: ProviderId[];
+}
+
+export interface AggregateUsageResult {
+  rowsByProvider: Record<ProviderId, UsageSummary | null>;
+  warnings: string[];
 }
 
 export async function aggregateUsage({
   start,
   end,
-  providers,
-}: AggregateUsageOptions): Promise<Record<ProviderId, UsageSummary | null>> {
-  const requestedProviders = providers?.length ? providers : providerIds;
+  requestedProviders,
+}: AggregateUsageOptions): Promise<AggregateUsageResult> {
+  const providersToLoad =
+    requestedProviders?.length ? requestedProviders : providerIds;
   const rowsByProvider: Record<ProviderId, UsageSummary | null> = {
     claude: null,
     codex: null,
     opencode: null,
   };
+  const warnings: string[] = [];
 
-  for (const provider of requestedProviders) {
+  for (const provider of providersToLoad) {
     const summary =
       provider === "claude"
         ? await loadClaudeRows(start, end)
         : provider === "codex"
-          ? await loadCodexRows(start, end)
+          ? await loadCodexRows(start, end, warnings)
           : await loadOpenCodeRows(start, end);
 
     rowsByProvider[provider] = hasUsage(summary) ? summary : null;
   }
 
-  return rowsByProvider;
+  return { rowsByProvider, warnings };
 }

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,0 +1,484 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+
+const cliPath = resolve(import.meta.dirname, "../dist/cli.js");
+
+function createTempWorkspace(label: string) {
+  return mkdtempSync(join(tmpdir(), `slopmeter-${label}-`));
+}
+
+function recentIso(daysAgo = 0) {
+  const date = new Date();
+
+  date.setUTCDate(date.getUTCDate() - daysAgo);
+
+  return date.toISOString();
+}
+
+function ensureParent(path: string) {
+  mkdirSync(dirname(path), { recursive: true });
+}
+
+function writeJsonlFile(path: string, records: string[]) {
+  ensureParent(path);
+  writeFileSync(path, `${records.join("\n")}\n`, "utf8");
+}
+
+function writeJsonFile(path: string, value: string) {
+  ensureParent(path);
+  writeFileSync(path, value, "utf8");
+}
+
+function codexTurnContext(model = "gpt-5") {
+  return JSON.stringify({
+    type: "turn_context",
+    timestamp: recentIso(),
+    payload: { model },
+  });
+}
+
+function codexTokenCount(options: {
+  model?: string;
+  timestamp?: string;
+  input?: number;
+  output?: number;
+  total?: number;
+  padding?: string;
+}) {
+  const {
+    model = "gpt-5",
+    timestamp = recentIso(),
+    input = 10,
+    output = 5,
+    total = input + output,
+    padding,
+  } = options;
+
+  return JSON.stringify({
+    type: "event_msg",
+    timestamp,
+    payload: {
+      type: "token_count",
+      model,
+      padding,
+      info: {
+        last_token_usage: {
+          input_tokens: input,
+          output_tokens: output,
+          total_tokens: total,
+        },
+      },
+    },
+  });
+}
+
+function codexOversizedIrrelevantRecord(size: number) {
+  return JSON.stringify({
+    type: "response_item",
+    timestamp: recentIso(),
+    payload: {
+      type: "function_call_output",
+      output: "x".repeat(size),
+    },
+  });
+}
+
+function claudeEntry(options: {
+  timestamp?: string;
+  messageId: string;
+  requestId: string;
+  model?: string;
+  input?: number;
+  output?: number;
+}) {
+  const {
+    timestamp = recentIso(),
+    messageId,
+    requestId,
+    model = "claude-3-5-sonnet-20241022",
+    input = 6,
+    output = 4,
+  } = options;
+
+  return JSON.stringify({
+    timestamp,
+    requestId,
+    message: {
+      id: messageId,
+      model,
+      usage: {
+        input_tokens: input,
+        output_tokens: output,
+      },
+    },
+  });
+}
+
+function openCodeMessage(options: {
+  id?: string;
+  modelID?: string;
+  created?: number;
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+}) {
+  const {
+    id = "msg-1",
+    modelID = "gpt-5.4",
+    created = Date.now(),
+    input = 6,
+    output = 4,
+    cacheRead = 0,
+    cacheWrite = 0,
+  } = options;
+
+  return JSON.stringify({
+    id,
+    modelID,
+    providerID: "openai",
+    time: { created, completed: created + 1_000 },
+    tokens: {
+      total: input + output + cacheRead + cacheWrite,
+      input,
+      output,
+      reasoning: 0,
+      cache: {
+        read: cacheRead,
+        write: cacheWrite,
+      },
+    },
+  });
+}
+
+async function runCli(
+  args: string[],
+  extraEnv: Record<string, string>,
+) {
+  return await new Promise<{
+    code: number | null;
+    stdout: string;
+    stderr: string;
+  }>((resolveRun, reject) => {
+    const child = spawn(process.execPath, [cliPath, ...args], {
+      env: {
+        ...process.env,
+        ...extraEnv,
+        FORCE_COLOR: "0",
+        NO_COLOR: "1",
+        TERM: "dumb",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolveRun({ code, stdout, stderr });
+    });
+  });
+}
+
+test("--codex only loads Codex and only reports Codex availability", async (t) => {
+  const workspace = createTempWorkspace("codex-only");
+
+  t.after(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  const codexHome = join(workspace, "codex");
+  const claudeConfig = join(workspace, "claude");
+  const openCodeDir = join(workspace, "opencode");
+  const outputPath = join(workspace, "out.json");
+  const unreadableClaudeFile = join(claudeConfig, "projects", "bad.jsonl");
+
+  writeJsonlFile(join(codexHome, "sessions", "session.jsonl"), [
+    codexTurnContext(),
+    codexTokenCount({ input: 12, output: 8, total: 20 }),
+  ]);
+  writeJsonlFile(unreadableClaudeFile, ['{"broken":true}']);
+  chmodSync(unreadableClaudeFile, 0o000);
+  writeJsonFile(
+    join(openCodeDir, "storage", "message", "bad.json"),
+    "{ this is not valid json",
+  );
+
+  const result = await runCli(
+    ["--codex", "--format", "json", "--output", outputPath],
+    {
+      CODEX_HOME: codexHome,
+      CLAUDE_CONFIG_DIR: claudeConfig,
+      OPENCODE_DATA_DIR: openCodeDir,
+    },
+  );
+
+  assert.equal(result.code, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /Codex found/);
+  assert.doesNotMatch(result.stdout, /Claude code/);
+  assert.doesNotMatch(result.stdout, /Open Code/);
+
+  const payload = JSON.parse(readFileSync(outputPath, "utf8")) as {
+    providers: Array<{ provider: string; daily: Array<{ total: number }> }>;
+  };
+
+  assert.deepEqual(
+    payload.providers.map((provider) => provider.provider),
+    ["codex"],
+  );
+  assert.equal(payload.providers[0]?.daily[0]?.total, 20);
+});
+
+test("Codex skips oversized irrelevant records and still counts token usage", async (t) => {
+  const workspace = createTempWorkspace("codex-oversized-irrelevant");
+
+  t.after(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  const codexHome = join(workspace, "codex");
+  const outputPath = join(workspace, "out.json");
+
+  writeJsonlFile(join(codexHome, "sessions", "session.jsonl"), [
+    codexTurnContext(),
+    codexOversizedIrrelevantRecord(1024),
+    codexTokenCount({ input: 9, output: 6, total: 15 }),
+  ]);
+
+  const result = await runCli(
+    ["--codex", "--format", "json", "--output", outputPath],
+    {
+      CODEX_HOME: codexHome,
+      SLOPMETER_MAX_JSONL_RECORD_BYTES: "256",
+    },
+  );
+
+  assert.equal(result.code, 0, result.stderr || result.stdout);
+  assert.match(
+    result.stderr,
+    /Skipped 1 oversized irrelevant Codex record\(s\)/,
+  );
+
+  const payload = JSON.parse(readFileSync(outputPath, "utf8")) as {
+    providers: Array<{ provider: string; daily: Array<{ total: number }> }>;
+  };
+
+  assert.equal(payload.providers[0]?.daily[0]?.total, 15);
+});
+
+test("Codex fails clearly on oversized relevant records", async (t) => {
+  const workspace = createTempWorkspace("codex-oversized-relevant");
+
+  t.after(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  const codexHome = join(workspace, "codex");
+  const oversizedFile = join(codexHome, "sessions", "session.jsonl");
+
+  writeJsonlFile(oversizedFile, [
+    codexTurnContext(),
+    codexTokenCount({
+      input: 11,
+      output: 7,
+      total: 18,
+      padding: "x".repeat(1024),
+    }),
+  ]);
+
+  const result = await runCli(
+    ["--codex", "--format", "json", "--output", join(workspace, "out.json")],
+    {
+      CODEX_HOME: codexHome,
+      SLOPMETER_MAX_JSONL_RECORD_BYTES: "256",
+    },
+  );
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /Relevant Codex record exceeds 256 bytes/);
+  assert.match(result.stderr, new RegExp(oversizedFile.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(result.stderr, /SLOPMETER_MAX_JSONL_RECORD_BYTES/);
+});
+
+test("Claude JSONL streaming preserves usage results across multiple files", async (t) => {
+  const workspace = createTempWorkspace("claude-streaming");
+
+  t.after(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  const claudeConfig = join(workspace, "claude");
+  const outputPath = join(workspace, "out.json");
+
+  writeJsonlFile(join(claudeConfig, "projects", "one.jsonl"), [
+    claudeEntry({ messageId: "m-1", requestId: "r-1", input: 4, output: 6 }),
+    "{ malformed json",
+    claudeEntry({ messageId: "m-2", requestId: "r-2", input: 3, output: 2 }),
+  ]);
+  writeJsonlFile(join(claudeConfig, "projects", "two.jsonl"), [
+    claudeEntry({ messageId: "m-1", requestId: "r-1", input: 4, output: 6 }),
+    claudeEntry({ messageId: "m-3", requestId: "r-3", input: 5, output: 5 }),
+  ]);
+
+  const result = await runCli(
+    ["--claude", "--format", "json", "--output", outputPath],
+    {
+      CLAUDE_CONFIG_DIR: claudeConfig,
+    },
+  );
+
+  assert.equal(result.code, 0, result.stderr || result.stdout);
+
+  const payload = JSON.parse(readFileSync(outputPath, "utf8")) as {
+    providers: Array<{ provider: string; daily: Array<{ total: number }> }>;
+  };
+
+  assert.deepEqual(
+    payload.providers.map((provider) => provider.provider),
+    ["claude"],
+  );
+  assert.equal(payload.providers[0]?.daily[0]?.total, 25);
+});
+
+test("Claude fails clearly on oversized JSONL records via the shared splitter", async (t) => {
+  const workspace = createTempWorkspace("claude-oversized");
+
+  t.after(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  const claudeConfig = join(workspace, "claude");
+  const oversizedFile = join(claudeConfig, "projects", "oversized.jsonl");
+
+  writeJsonlFile(oversizedFile, [
+    claudeEntry({
+      messageId: "m-1",
+      requestId: "r-1",
+      input: 3,
+      output: 2,
+    }),
+    JSON.stringify({
+      timestamp: recentIso(),
+      requestId: "r-2",
+      message: {
+        id: "m-2",
+        model: "claude-3-5-sonnet-20241022",
+        usage: {
+          input_tokens: 4,
+          output_tokens: 1,
+        },
+        padding: "x".repeat(1024),
+      },
+    }),
+  ]);
+
+  const result = await runCli(
+    ["--claude", "--format", "json", "--output", join(workspace, "out.json")],
+    {
+      CLAUDE_CONFIG_DIR: claudeConfig,
+      SLOPMETER_MAX_JSONL_RECORD_BYTES: "256",
+    },
+  );
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /JSONL record exceeds 256 bytes/);
+  assert.match(
+    result.stderr,
+    new RegExp(oversizedFile.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+  );
+  assert.match(result.stderr, /SLOPMETER_MAX_JSONL_RECORD_BYTES/);
+});
+
+test("OpenCode reads the legacy file-backed message layout", async (t) => {
+  const workspace = createTempWorkspace("opencode-files");
+
+  t.after(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  const openCodeDir = join(workspace, "opencode");
+  const outputPath = join(workspace, "out.json");
+
+  writeJsonFile(
+    join(openCodeDir, "storage", "message", "one.json"),
+    openCodeMessage({
+      id: "msg-1",
+      input: 8,
+      output: 5,
+      cacheRead: 2,
+    }),
+  );
+
+  const result = await runCli(
+    ["--opencode", "--format", "json", "--output", outputPath],
+    {
+      OPENCODE_DATA_DIR: openCodeDir,
+    },
+  );
+
+  assert.equal(result.code, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /Open Code found/);
+
+  const payload = JSON.parse(readFileSync(outputPath, "utf8")) as {
+    providers: Array<{ provider: string; daily: Array<{ total: number }> }>;
+  };
+
+  assert.deepEqual(
+    payload.providers.map((provider) => provider.provider),
+    ["opencode"],
+  );
+  assert.equal(payload.providers[0]?.daily[0]?.total, 15);
+});
+
+test("OpenCode fails clearly on oversized JSON documents", async (t) => {
+  const workspace = createTempWorkspace("opencode-oversized");
+
+  t.after(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  const openCodeDir = join(workspace, "opencode");
+  const oversizedFile = join(
+    openCodeDir,
+    "storage",
+    "message",
+    "oversized.json",
+  );
+
+  writeJsonFile(
+    oversizedFile,
+    `${openCodeMessage({
+      input: 1,
+      output: 1,
+    }).slice(0, -1)},"padding":"${"x".repeat(1024)}"}`,
+  );
+
+  const result = await runCli(
+    ["--opencode", "--format", "json", "--output", join(workspace, "out.json")],
+    {
+      OPENCODE_DATA_DIR: openCodeDir,
+      SLOPMETER_MAX_JSONL_RECORD_BYTES: "256",
+    },
+  );
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /JSON document exceeds 256 bytes/);
+  assert.match(
+    result.stderr,
+    new RegExp(oversizedFile.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+  );
+  assert.match(result.stderr, /SLOPMETER_MAX_JSONL_RECORD_BYTES/);
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tooling/typescript-config/node.json",
-  "include": ["src/**/*.ts", "tsup.config.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts", "tsup.config.ts"]
 }


### PR DESCRIPTION
## Summary
- decide requested providers before loading so provider flags do not trigger unrelated scans
- stream JSONL records instead of materializing files, with a shared 64 MB per-record bound and safer default file concurrency of 4
- add Codex record classification so oversized irrelevant records are skipped without JSON.parse while oversized relevant records fail clearly
- add legacy OpenCode JSON document bounds and regression coverage for Claude, Codex, and OpenCode

## Verification
- bun run --cwd packages/cli typecheck
- bun run --cwd packages/cli test
- bun run --cwd packages/cli lint
- npm pack
- npx --yes --package=./slopmeter-0.2.0.tgz slopmeter --codex --format json --output /tmp/slopmeter-npx-codex.json
- /usr/bin/time -l node dist/cli.js --codex on real dataset

## Perf
- main: failed with `Unterminated string in JSON at position 204` after `3415867392` max RSS
- this branch: completed successfully with `409141248` max RSS and warned about 2 oversized irrelevant Codex records

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound and streamed JSON ingestion across Codex, Claude Code, and OpenCode to prevent OOMs and avoid unnecessary scans. Provider flags now limit loading and availability output to only the requested providers, with clear warnings and errors.

- New Features
  - Streamed JSONL for Claude Code and Codex with a 64 MB per-record cap and safer default file concurrency of 4; tunable via `SLOPMETER_MAX_JSONL_RECORD_BYTES` and `SLOPMETER_FILE_PROCESS_CONCURRENCY`.
  - Codex: classify records up front, parse only usage-related events, skip oversized irrelevant records with a summary warning, and fail oversized relevant records with precise file/line messages.
  - OpenCode: bounded JSON document reader before `JSON.parse`, with clear oversized-file errors.
  - CLI: show warnings after aggregation; when provider flags are present, only load those providers and only print availability for them. Docs updated in README and `packages/cli/README.md`.

- Bug Fixes
  - Fix OOM/parse failures from materializing large JSONL/JSON by streaming with size limits (real dataset improved from ~3.4 GB RSS and failure to ~0.4 GB RSS and success).
  - Prevent unrelated provider scans when flags are passed, with regression tests added in `packages/cli/test` and a `test` script in `packages/cli/package.json`.

<sup>Written for commit 2d1b9ba612ad91ac1379a64fc95cc1d6b5d16fba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

