### PR TITLE
fix: always include default config paths in claude data discovery

### DIFF
--- a/packages/cli/src/lib/claude-code.ts
+++ b/packages/cli/src/lib/claude-code.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import type { UsageSummary } from "../interfaces";
@@ -71,21 +71,57 @@ interface ClaudeHistoryEntry {
   timestamp?: number | string;
 }
 
-function getClaudeConfigPaths() {
-  const envPaths = (process.env[CLAUDE_CONFIG_DIR_ENV] ?? "").trim();
+function discoverClaudeWorkDirs() {
+  const home = homedir();
 
-  if (envPaths !== "") {
-    return envPaths
-      .split(",")
-      .map((path) => path.trim())
-      .filter((path) => path !== "")
-      .map((path) => resolve(path));
+  try {
+    return readdirSync(home, { withFileTypes: true })
+      .filter((entry) => {
+        if (!entry.isDirectory() || !entry.name.startsWith(".claude-")) {
+          return false;
+        }
+
+        const dir = join(home, entry.name);
+
+        return (
+          existsSync(join(dir, CLAUDE_PROJECTS_DIR_NAME)) ||
+          existsSync(join(dir, CLAUDE_STATS_CACHE_FILE_NAME))
+        );
+      })
+      .map((entry) => join(home, entry.name));
+  } catch {
+    return [];
   }
+}
 
+function getClaudeConfigPaths() {
   const xdgConfigHome =
     process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), ".config");
 
-  return [join(xdgConfigHome, "claude"), join(homedir(), ".claude")];
+  const defaults = [join(xdgConfigHome, "claude"), join(homedir(), ".claude")];
+
+  const envPaths = (process.env[CLAUDE_CONFIG_DIR_ENV] ?? "").trim();
+
+  const envResolved =
+    envPaths === ""
+      ? []
+      : envPaths
+          .split(",")
+          .map((path) => path.trim())
+          .filter((path) => path !== "")
+          .map((path) => resolve(path));
+
+  const seen = new Set(envResolved);
+  const paths = [...envResolved];
+
+  for (const path of [...defaults, ...discoverClaudeWorkDirs()]) {
+    if (!seen.has(path)) {
+      seen.add(path);
+      paths.push(path);
+    }
+  }
+
+  return paths;
 }
 
 function getClaudeProjectDirs() {


### PR DESCRIPTION
## Summary
- When `CLAUDE_CONFIG_DIR` is set (e.g. automatically by Claude Code itself), the default paths `~/.claude` and `~/.config/claude` were skipped entirely, causing most usage data to be missing from the heatmap
- Now always includes default config paths alongside any `CLAUDE_CONFIG_DIR` value
- Auto-discovers `~/.claude-*` work directories (e.g. `~/.claude-work`) so additional Claude working directories are included without manual configuration

## Test plan
- [ ] Run `slopmeter --claude` from within a Claude Code session (where `CLAUDE_CONFIG_DIR` is set) and verify all usage data appears
- [ ] Verify `~/.claude-work` and similar directories are discovered automatically
- [ ] Verify no duplicate data when paths overlap

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing Claude usage data in the heatmap by always including default config dirs and discovering valid `~/.claude-*` work dirs, even when `CLAUDE_CONFIG_DIR` is set.

- **Bug Fixes**
  - Always include `~/.claude` and `~/.config/claude` alongside `CLAUDE_CONFIG_DIR`.
  - Deduplicate overlapping paths to prevent double counting.

- **New Features**
  - Auto-discovers `~/.claude-*` work dirs (e.g., `~/.claude-work`) and only includes ones with projects or stats.

<sup>Written for commit 8048e2e26e10e3ba7737f9b6670100f2c6a28d94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

