### PR TITLE
Suffix default output filenames by provider flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ slopmeter
 ### Options
 
 ```bash
-# Output file (default: ./heatmap-last-year.png)
+# Output file (default: `./heatmap-last-year.png`; explicit provider flags add suffixes like `./heatmap-last-year_cursor.png`, and `--all` uses `./heatmap-last-year_all.png`)
 slopmeter --output ./out/heatmap.svg
 slopmeter -o ./out/heatmap.svg
 
@@ -83,6 +83,7 @@ Model names are normalized to remove a trailing date suffix like `-20251101`.
 ## Format behavior
 
 - Default format is PNG.
+- If `--output` is omitted, the default filename is `heatmap-last-year.<ext>`, `heatmap-last-year_<providers>.<ext>` for explicit provider flags, or `heatmap-last-year_all.<ext>` for `--all`.
 - If `--format` is omitted, format is inferred from `--output` extension (`.png`, `.svg`, or `.json`).
 - If neither provides a format, PNG is used.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -108,6 +108,7 @@ npx slopmeter --dark --format svg --output ./out/heatmap-dark.svg
 ## Output behavior
 
 - If `--format` is omitted, the format is inferred from the `--output` extension when possible.
+- If `--output` is omitted, the default filename becomes `heatmap-last-year.<ext>`, `heatmap-last-year_<providers>.<ext>` for explicit provider flags, or `heatmap-last-year_all.<ext>` for `--all`.
 - Supported extensions are `.png`, `.svg`, and `.json`.
 - If neither `--format` nor a recognized output extension is provided, PNG is used.
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -11,6 +11,7 @@ import type {
   UsageSummary,
   UsageProviderId,
 } from "./interfaces";
+import { getDefaultOutputPath } from "./output-path";
 import type { ProviderId } from "./providers";
 import { formatLocalDate } from "./lib/utils";
 import {
@@ -384,7 +385,7 @@ async function main() {
     );
 
     const outputPath = resolve(
-      values.output ?? `./heatmap-last-year.${format}`,
+      values.output ?? getDefaultOutputPath(values, format),
     );
 
     mkdirSync(dirname(outputPath), { recursive: true });

--- a/packages/cli/src/output-path.ts
+++ b/packages/cli/src/output-path.ts
@@ -4,17 +4,21 @@ type OutputFormat = "png" | "svg" | "json";
 
 interface ProviderSelectionValues {
   all: boolean;
+  amp: boolean;
   claude: boolean;
   codex: boolean;
   cursor: boolean;
+  gemini: boolean;
   opencode: boolean;
   pi: boolean;
 }
 
 const outputProviderIds: ProviderId[] = [
+  "amp",
   "claude",
   "codex",
   "cursor",
+  "gemini",
   "opencode",
   "pi",
 ];

--- a/packages/cli/src/output-path.ts
+++ b/packages/cli/src/output-path.ts
@@ -1,0 +1,47 @@
+import type { ProviderId } from "./lib/interfaces";
+
+type OutputFormat = "png" | "svg" | "json";
+
+interface ProviderSelectionValues {
+  all: boolean;
+  claude: boolean;
+  codex: boolean;
+  cursor: boolean;
+  opencode: boolean;
+  pi: boolean;
+}
+
+const outputProviderIds: ProviderId[] = [
+  "claude",
+  "codex",
+  "cursor",
+  "opencode",
+  "pi",
+];
+
+export function getRequestedProvidersForOutput(
+  values: ProviderSelectionValues,
+) {
+  return outputProviderIds.filter((provider) => values[provider]);
+}
+
+export function getDefaultOutputSuffix(values: ProviderSelectionValues) {
+  if (values.all) {
+    return "_all";
+  }
+
+  const requestedProviders = getRequestedProvidersForOutput(values);
+
+  if (requestedProviders.length === 0) {
+    return "";
+  }
+
+  return `_${requestedProviders.join("_")}`;
+}
+
+export function getDefaultOutputPath(
+  values: ProviderSelectionValues,
+  format: OutputFormat,
+) {
+  return `./heatmap-last-year${getDefaultOutputSuffix(values)}.${format}`;
+}

--- a/packages/cli/test/output-path.test.ts
+++ b/packages/cli/test/output-path.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getDefaultOutputPath,
+  getDefaultOutputSuffix,
+} from "../src/output-path.ts";
+
+function createValues(overrides?: Partial<{
+  all: boolean;
+  claude: boolean;
+  codex: boolean;
+  cursor: boolean;
+  opencode: boolean;
+  pi: boolean;
+}>) {
+  return {
+    all: false,
+    claude: false,
+    codex: false,
+    cursor: false,
+    opencode: false,
+    pi: false,
+    ...overrides,
+  };
+}
+
+test("default output path stays unsuffixed when no provider flags are set", () => {
+  assert.equal(
+    getDefaultOutputPath(createValues(), "png"),
+    "./heatmap-last-year.png",
+  );
+});
+
+test("default output path adds _cursor for --cursor", () => {
+  assert.equal(
+    getDefaultOutputPath(createValues({ cursor: true }), "png"),
+    "./heatmap-last-year_cursor.png",
+  );
+});
+
+test("default output path adds _all for --all", () => {
+  assert.equal(
+    getDefaultOutputPath(createValues({ all: true, cursor: true }), "json"),
+    "./heatmap-last-year_all.json",
+  );
+});
+
+test("default output path reflects multiple explicit provider flags", () => {
+  assert.equal(
+    getDefaultOutputPath(
+      createValues({ codex: true, cursor: true, pi: true }),
+      "svg",
+    ),
+    "./heatmap-last-year_codex_cursor_pi.svg",
+  );
+});
+
+test("default output suffix follows provider flag order", () => {
+  assert.equal(
+    getDefaultOutputSuffix(
+      createValues({ pi: true, claude: true, opencode: true }),
+    ),
+    "_claude_opencode_pi",
+  );
+});

--- a/packages/cli/test/output-path.test.ts
+++ b/packages/cli/test/output-path.test.ts
@@ -7,17 +7,21 @@ import {
 
 function createValues(overrides?: Partial<{
   all: boolean;
+  amp: boolean;
   claude: boolean;
   codex: boolean;
   cursor: boolean;
+  gemini: boolean;
   opencode: boolean;
   pi: boolean;
 }>) {
   return {
     all: false,
+    amp: false,
     claude: false,
     codex: false,
     cursor: false,
+    gemini: false,
     opencode: false,
     pi: false,
     ...overrides,
@@ -58,8 +62,8 @@ test("default output path reflects multiple explicit provider flags", () => {
 test("default output suffix follows provider flag order", () => {
   assert.equal(
     getDefaultOutputSuffix(
-      createValues({ pi: true, claude: true, opencode: true }),
+      createValues({ pi: true, gemini: true, amp: true, opencode: true }),
     ),
-    "_claude_opencode_pi",
+    "_amp_gemini_opencode_pi",
   );
 });


### PR DESCRIPTION
## Summary
- derive the default output filename from the selected provider flags when --output is omitted
- use _all for merged output and join explicit provider flags in provider order
- document the default filename behavior and add focused coverage for the naming helper

## Verification
- npm --workspace packages/cli run build
- node --experimental-strip-types --test packages/cli/test/output-path.test.ts

## Notes
- the full packages/cli test script was not run in this sandbox because tsx --test requires an IPC socket that is blocked here

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derive default output filenames from selected provider flags when `--output` is omitted, adding `_all` for `--all` or joining explicit providers in order (e.g., `heatmap-last-year_cursor.png`). This makes outputs clear when exporting multiple providers.

- **New Features**
  - Added `getDefaultOutputPath`/`getDefaultOutputSuffix` in `packages/cli` to build `./heatmap-last-year[_<providers>|_all].<ext>`.
  - `cli.ts` now uses this helper for default paths.
  - Updated `README.md` docs and added focused tests for suffix ordering and cases.

- **Bug Fixes**
  - Suffix generation now considers all provider flags (`amp`, `claude`, `codex`, `cursor`, `gemini`, `opencode`, `pi`).

<sup>Written for commit 3797c8fc4d2ababf2f5ad9e3156f326f2bd6cd1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

