### PR TITLE
Add Gemini CLI provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # slopmeter
 
-CLI tool that generates usage heatmaps for Claude Code, Codex, Cursor, Open Code, and Pi Coding Agent for the rolling past year (ending today).
+CLI tool that generates usage heatmaps for Claude Code, Codex, Cursor, Gemini CLI, Open Code, and Pi Coding Agent for the rolling past year (ending today).
 
 ## Monorepo layout
 
@@ -59,6 +59,7 @@ slopmeter --all
 slopmeter --claude
 slopmeter --codex
 slopmeter --cursor
+slopmeter --gemini
 slopmeter --opencode
 slopmeter --pi
 ```
@@ -127,5 +128,6 @@ Model names are normalized to remove a trailing date suffix like `-20251101`.
 - Claude Code: `$CLAUDE_CONFIG_DIR/*/projects` (comma-separated dirs) or defaults `~/.config/claude/projects` and `~/.claude/projects`
 - Codex: `$CODEX_HOME/sessions` or `~/.codex/sessions`
 - Cursor: reads `cursorAuth/accessToken` and `cursorAuth/refreshToken` from `$CURSOR_STATE_DB_PATH`, `$CURSOR_CONFIG_DIR/User/globalStorage/state.vscdb`, `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` (macOS), `%APPDATA%/Cursor/User/globalStorage/state.vscdb` (Windows), or `~/.config/Cursor/User/globalStorage/state.vscdb` (Linux), then loads usage from Cursor's CSV export endpoint
+- Gemini CLI: `$GEMINI_CONFIG_DIR/tmp/**/chats/session-*.json` or `~/.gemini/tmp/**/chats/session-*.json`
 - Open Code: prefers `$OPENCODE_DATA_DIR/opencode.db` or `~/.local/share/opencode/opencode.db`, and falls back to `$OPENCODE_DATA_DIR/storage/message` or `~/.local/share/opencode/storage/message`
 - Pi Coding Agent: `$PI_CODING_AGENT_DIR/sessions` or `~/.pi/agent/sessions`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # slopmeter
 
-`slopmeter` is a Node.js CLI that scans local Claude Code, Codex, Cursor, Open Code, and Pi Coding Agent usage data and generates a contribution-style heatmap for the rolling past year.
+`slopmeter` is a Node.js CLI that scans local Claude Code, Codex, Cursor, Gemini CLI, Open Code, and Pi Coding Agent usage data and generates a contribution-style heatmap for the rolling past year.
 
 ## Requirements
 
@@ -24,7 +24,7 @@ slopmeter
 ## Usage
 
 ```bash
-slopmeter [--all] [--claude] [--codex] [--cursor] [--opencode] [--pi] [--dark] [--format png|svg|json] [--output ./heatmap-last-year.png]
+slopmeter [--all] [--claude] [--codex] [--cursor] [--gemini] [--opencode] [--pi] [--dark] [--format png|svg|json] [--output ./heatmap-last-year.png]
 ```
 
 By default, the CLI:
@@ -38,6 +38,7 @@ By default, the CLI:
 - `--claude`: include only Claude Code data
 - `--codex`: include only Codex data
 - `--cursor`: include only Cursor data
+- `--gemini`: include only Gemini CLI data
 - `--opencode`: include only Open Code data
 - `--pi`: include only Pi Coding Agent data
 - `--all`: merge all providers into one combined graph
@@ -78,6 +79,12 @@ Render only Cursor usage:
 npx slopmeter --cursor
 ```
 
+Render only Gemini CLI usage:
+
+```bash
+npx slopmeter --gemini
+```
+
 Render only Pi Coding Agent usage:
 
 ```bash
@@ -111,6 +118,7 @@ npx slopmeter --dark --format svg --output ./out/heatmap-dark.svg
 - Earliest Claude Code activity fallback: uses `$CLAUDE_CONFIG_DIR/history.jsonl`, `~/.config/claude/history.jsonl`, or `~/.claude/history.jsonl` to mark activity-only days when token totals are unavailable
 - Codex: `$CODEX_HOME/sessions` or `~/.codex/sessions`
 - Cursor: reads `cursorAuth/accessToken` and `cursorAuth/refreshToken` from `$CURSOR_STATE_DB_PATH`, `$CURSOR_CONFIG_DIR/User/globalStorage/state.vscdb`, `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` (macOS), `%APPDATA%/Cursor/User/globalStorage/state.vscdb` (Windows), or `~/.config/Cursor/User/globalStorage/state.vscdb` (Linux), then loads usage from Cursor's CSV export endpoint
+- Gemini CLI: `$GEMINI_CONFIG_DIR/tmp/**/chats/session-*.json` or `~/.gemini/tmp/**/chats/session-*.json`
 - Open Code: prefers `$OPENCODE_DATA_DIR/opencode.db` or `~/.local/share/opencode/opencode.db`, and falls back to `$OPENCODE_DATA_DIR/storage/message` or `~/.local/share/opencode/storage/message`
 - Pi Coding Agent: `$PI_CODING_AGENT_DIR/sessions` or `~/.pi/agent/sessions`
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slopmeter",
   "version": "0.5.1",
-  "description": "CLI for generating yearly usage heatmaps for Claude Code, Codex, Cursor, Open Code, and Pi Coding Agent.",
+  "description": "CLI for generating yearly usage heatmaps for Claude Code, Codex, Cursor, Gemini CLI, Open Code, and Pi Coding Agent.",
   "type": "module",
   "engines": {
     "node": ">=22"
@@ -23,6 +23,7 @@
     "codex",
     "claude-code",
     "cursor",
+    "gemini-cli",
     "opencode",
     "pi-coding-agent"
   ],

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -32,6 +32,7 @@ interface CliArgValues {
   claude: boolean;
   codex: boolean;
   cursor: boolean;
+  gemini: boolean;
   opencode: boolean;
   pi: boolean;
 }
@@ -39,20 +40,21 @@ interface CliArgValues {
 const PNG_BASE_WIDTH = 1000;
 const PNG_SCALE = 4;
 const PNG_RENDER_WIDTH = PNG_BASE_WIDTH * PNG_SCALE;
-const JSON_EXPORT_VERSION = "2026-03-03";
+const JSON_EXPORT_VERSION = "2026-03-13";
 
 const HELP_TEXT = `slopmeter
 
 Generate rolling 1-year usage heatmap image(s) (today is the latest day).
 
 Usage:
-  slopmeter [--all] [--claude] [--codex] [--cursor] [--opencode] [--pi] [--dark] [--format png|svg|json] [--output ./heatmap-last-year.png]
+  slopmeter [--all] [--claude] [--codex] [--cursor] [--gemini] [--opencode] [--pi] [--dark] [--format png|svg|json] [--output ./heatmap-last-year.png]
 
 Options:
   --all                       Render one merged graph for all providers
   --claude                    Render Claude Code graph
   --codex                     Render Codex graph
   --cursor                    Render Cursor graph
+  --gemini                    Render Gemini CLI graph
   --opencode                  Render Open Code graph
   --pi                        Render Pi Coding Agent graph
   --dark                      Render with the dark theme
@@ -77,6 +79,7 @@ function validateArgs(values: unknown): asserts values is CliArgValues {
       claude: ow.boolean,
       codex: ow.boolean,
       cursor: ow.boolean,
+      gemini: ow.boolean,
       opencode: ow.boolean,
       pi: ow.boolean,
     }),
@@ -177,6 +180,18 @@ function getRequestedProviders(values: CliArgValues) {
   return providerIds.filter((id) => values[id]);
 }
 
+function getMergedNoDataMessage() {
+  return "No usage data found for Claude Code, Codex, Cursor, Gemini CLI, Open Code, or Pi Coding Agent.";
+}
+
+function getRequestedMissingProvidersMessage(missing: ProviderId[]) {
+  return `Requested provider data not found: ${missing.map((provider) => providerStatusLabel[provider]).join(", ")}`;
+}
+
+function getNoDataMessage() {
+  return getMergedNoDataMessage();
+}
+
 function getOutputProviders(
   values: CliArgValues,
   availabilityByProvider: Record<ProviderId, boolean>,
@@ -194,7 +209,7 @@ function getOutputProviders(
   const merged = mergeProviderUsage(rowsByProvider, end);
 
   if (!merged) {
-    throw new Error("No usage data found for any provider.");
+    throw new Error(getMergedNoDataMessage());
   }
 
   return [merged];
@@ -246,9 +261,7 @@ function selectProvidersToRender(
   if (requested.length > 0 && providersToRender.length < requested.length) {
     const missing = requested.filter((provider) => !rowsByProvider[provider]);
 
-    throw new Error(
-      `Requested provider data not found: ${missing.map((provider) => providerStatusLabel[provider]).join(", ")}`,
-    );
+    throw new Error(getRequestedMissingProvidersMessage(missing));
   }
 
   if (providersToRender.length === 0) {
@@ -269,9 +282,7 @@ function selectProvidersToRender(
       );
     }
 
-    throw new Error(
-      "No usage data found for any provider.",
-    );
+    throw new Error(getNoDataMessage());
   }
 
   return providersToRender.map((provider) => rowsByProvider[provider]!);
@@ -314,6 +325,7 @@ async function main() {
       claude: { type: "boolean", default: false },
       codex: { type: "boolean", default: false },
       cursor: { type: "boolean", default: false },
+      gemini: { type: "boolean", default: false },
       opencode: { type: "boolean", default: false },
       pi: { type: "boolean", default: false },
     },

--- a/packages/cli/src/graph.ts
+++ b/packages/cli/src/graph.ts
@@ -136,6 +136,25 @@ export const heatmapThemes: Record<HeatmapThemeId, HeatmapTheme> = {
       ],
     },
   },
+  gemini: {
+    title: "Gemini CLI",
+    colors: {
+      light: [
+        "#eff6ff", // blue-50
+        "#bfdbfe", // blue-200
+        "#93c5fd", // blue-300
+        "#3b82f6", // blue-500
+        "#1d4ed8", // blue-700
+      ],
+      dark: [
+        "#172554", // blue-950
+        "#1d4ed8", // blue-700
+        "#2563eb", // blue-600
+        "#60a5fa", // blue-400
+        "#bfdbfe", // blue-200
+      ],
+    },
+  },
   opencode: {
     title: "Open Code",
     colors: {
@@ -175,7 +194,8 @@ export const heatmapThemes: Record<HeatmapThemeId, HeatmapTheme> = {
     },
   },
   all: {
-    title: "Codex / Claude Code / Cursor / Open Code / Pi Coding Agent",
+    title:
+      "Claude Code / Codex / Cursor / Gemini CLI / Open Code / Pi Coding Agent",
     titleCaption: "Total usage from",
     colors: {
       light: [

--- a/packages/cli/src/interfaces.ts
+++ b/packages/cli/src/interfaces.ts
@@ -2,6 +2,7 @@ export type UsageProviderId =
   | "claude"
   | "codex"
   | "cursor"
+  | "gemini"
   | "opencode"
   | "pi"
   | "all";

--- a/packages/cli/src/lib/gemini.ts
+++ b/packages/cli/src/lib/gemini.ts
@@ -1,0 +1,157 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import type { UsageSummary } from "../interfaces";
+import {
+  type DailyTotalsByDate,
+  type DailyTokenTotals,
+  type ModelTokenTotals,
+  addDailyTokenTotals,
+  addModelTokenTotals,
+  createUsageSummary,
+  getRecentWindowStart,
+  listFilesRecursive,
+  normalizeModelName,
+  readJsonDocument,
+} from "./utils";
+
+const GEMINI_CONFIG_DIR_ENV = "GEMINI_CONFIG_DIR";
+const GEMINI_SESSION_PATH_RE = /[\\/]chats[\\/]session-[^\\/]+\.json$/;
+
+interface GeminiTokens {
+  input?: number;
+  output?: number;
+  cached?: number;
+  thoughts?: number;
+  tool?: number;
+}
+
+interface GeminiMessage {
+  id?: string;
+  timestamp?: string;
+  type?: string;
+  model?: string;
+  tokens?: GeminiTokens;
+}
+
+interface GeminiSession {
+  messages?: GeminiMessage[];
+}
+
+function getGeminiBaseDir() {
+  const configuredDir = process.env[GEMINI_CONFIG_DIR_ENV]?.trim();
+
+  return configuredDir ? resolve(configuredDir) : join(homedir(), ".gemini");
+}
+
+async function getGeminiSessionFiles() {
+  const files = await listFilesRecursive(
+    join(getGeminiBaseDir(), "tmp"),
+    ".json",
+  );
+
+  return files.filter((file) => GEMINI_SESSION_PATH_RE.test(file));
+}
+
+export function isGeminiAvailable() {
+  return existsSync(join(getGeminiBaseDir(), "tmp"));
+}
+
+function createGeminiTokenTotals(tokens: GeminiTokens): DailyTokenTotals {
+  const cacheInput = tokens.cached ?? 0;
+  const input = (tokens.input ?? 0) + cacheInput;
+  const output =
+    (tokens.output ?? 0) + (tokens.thoughts ?? 0) + (tokens.tool ?? 0);
+
+  return {
+    input,
+    output,
+    cache: { input: cacheInput, output: 0 },
+    total: input + output,
+  };
+}
+
+function getGeminiMessageKey(message: GeminiMessage) {
+  if (message.id) {
+    return message.id;
+  }
+
+  return JSON.stringify({
+    timestamp: message.timestamp,
+    model: message.model,
+    tokens: message.tokens,
+  });
+}
+
+async function parseGeminiSession(filePath: string) {
+  return readJsonDocument<GeminiSession>(filePath, {
+    oversizedErrorMessage: ({ filePath, maxBytes, envVarName }) =>
+      `Gemini session JSON document exceeds ${maxBytes} bytes in ${filePath}. Increase ${envVarName} to process this file.`,
+  });
+}
+
+export async function loadGeminiRows(
+  start: Date,
+  end: Date,
+): Promise<UsageSummary> {
+  const files = await getGeminiSessionFiles();
+  const totals: DailyTotalsByDate = new Map();
+  const modelTotals = new Map<string, ModelTokenTotals>();
+  const recentModelTotals = new Map<string, ModelTokenTotals>();
+  const recentStart = getRecentWindowStart(end, 30);
+  const dedupe = new Set<string>();
+
+  for (const file of files) {
+    const session = await parseGeminiSession(file);
+
+    for (const message of session.messages ?? []) {
+      if (message.type !== "gemini" || !message.tokens) {
+        continue;
+      }
+
+      const date = message.timestamp ? new Date(message.timestamp) : null;
+
+      if (!date || Number.isNaN(date.getTime()) || date < start || date > end) {
+        continue;
+      }
+
+      const tokenTotals = createGeminiTokenTotals(message.tokens);
+
+      if (tokenTotals.total <= 0) {
+        continue;
+      }
+
+      const messageKey = getGeminiMessageKey(message);
+
+      if (dedupe.has(messageKey)) {
+        continue;
+      }
+
+      dedupe.add(messageKey);
+
+      const modelName = message.model?.trim()
+        ? normalizeModelName(message.model)
+        : undefined;
+
+      addDailyTokenTotals(totals, date, tokenTotals, modelName);
+
+      if (!modelName) {
+        continue;
+      }
+
+      addModelTokenTotals(modelTotals, modelName, tokenTotals);
+
+      if (date >= recentStart) {
+        addModelTokenTotals(recentModelTotals, modelName, tokenTotals);
+      }
+    }
+  }
+
+  return createUsageSummary(
+    "gemini",
+    totals,
+    modelTotals,
+    recentModelTotals,
+    end,
+  );
+}

--- a/packages/cli/src/lib/gemini.ts
+++ b/packages/cli/src/lib/gemini.ts
@@ -35,6 +35,7 @@ interface GeminiMessage {
 }
 
 interface GeminiSession {
+  sessionId?: string;
   messages?: GeminiMessage[];
 }
 
@@ -71,12 +72,13 @@ function createGeminiTokenTotals(tokens: GeminiTokens): DailyTokenTotals {
   };
 }
 
-function getGeminiMessageKey(message: GeminiMessage) {
-  if (message.id) {
-    return message.id;
-  }
-
+function getGeminiMessageKey(
+  sessionId: string | undefined,
+  message: GeminiMessage,
+) {
   return JSON.stringify({
+    sessionId,
+    messageId: message.id,
     timestamp: message.timestamp,
     model: message.model,
     tokens: message.tokens,
@@ -121,7 +123,7 @@ export async function loadGeminiRows(
         continue;
       }
 
-      const messageKey = getGeminiMessageKey(message);
+      const messageKey = getGeminiMessageKey(session.sessionId, message);
 
       if (dedupe.has(messageKey)) {
         continue;

--- a/packages/cli/src/lib/interfaces.ts
+++ b/packages/cli/src/lib/interfaces.ts
@@ -1,9 +1,16 @@
-export type ProviderId = "claude" | "codex" | "cursor" | "opencode" | "pi";
+export type ProviderId =
+  | "claude"
+  | "codex"
+  | "cursor"
+  | "gemini"
+  | "opencode"
+  | "pi";
 
 export const providerIds: ProviderId[] = [
   "claude",
   "codex",
   "cursor",
+  "gemini",
   "opencode",
   "pi",
 ];
@@ -14,6 +21,7 @@ export const providerStatusLabel: Record<ProviderId, string> = {
   claude: "Claude code",
   codex: "Codex",
   cursor: "Cursor",
+  gemini: "Gemini CLI",
   opencode: "Open Code",
   pi: "Pi Coding Agent",
 };

--- a/packages/cli/src/providers.ts
+++ b/packages/cli/src/providers.ts
@@ -2,6 +2,7 @@ import type { UsageSummary } from "./interfaces";
 import { isClaudeAvailable, loadClaudeRows } from "./lib/claude-code";
 import { isCodexAvailable, loadCodexRows } from "./lib/codex";
 import { isCursorAvailable, loadCursorRows } from "./lib/cursor";
+import { isGeminiAvailable, loadGeminiRows } from "./lib/gemini";
 import {
   defaultProviderIds,
   providerIds,
@@ -32,6 +33,7 @@ function createEmptyProviderAvailability(): ProviderAvailability {
     claude: false,
     codex: false,
     cursor: false,
+    gemini: false,
     opencode: false,
     pi: false,
   };
@@ -45,6 +47,8 @@ export async function isProviderAvailable(provider: ProviderId): Promise<boolean
       return isCodexAvailable();
     case "cursor":
       return isCursorAvailable();
+    case "gemini":
+      return isGeminiAvailable();
     case "opencode":
       return isOpenCodeAvailable();
     case "pi":
@@ -96,6 +100,7 @@ export async function aggregateUsage({
     claude: null,
     codex: null,
     cursor: null,
+    gemini: null,
     opencode: null,
     pi: null,
   };
@@ -113,6 +118,9 @@ export async function aggregateUsage({
         break;
       case "cursor":
         summary = await loadCursorRows(start, end);
+        break;
+      case "gemini":
+        summary = await loadGeminiRows(start, end);
         break;
       case "opencode":
         summary = await loadOpenCodeRows(start, end);

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -960,6 +960,90 @@ test("Gemini recomputes totals from cache/thoughts/tool tokens and deduplicates 
   );
 });
 
+test("Gemini keeps same message IDs from different sessions distinct", async (t) => {
+  const workspace = createTempWorkspace("gemini-session-scope");
+
+  t.after(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  const geminiDir = join(workspace, "gemini");
+  const outputPath = join(workspace, "out.json");
+
+  writeJsonFile(
+    join(geminiDir, "tmp", "project-a", "chats", "session-1.json"),
+    geminiSession({
+      sessionId: "gemini-session-a",
+      messages: [
+        geminiMessage({
+          id: "shared-message-id",
+          timestamp: `${recentDate(1)}T10:00:00.000Z`,
+          input: 4,
+          output: 3,
+          total: 7,
+        }),
+      ],
+    }),
+  );
+  writeJsonFile(
+    join(geminiDir, "tmp", "project-b", "chats", "session-2.json"),
+    geminiSession({
+      sessionId: "gemini-session-b",
+      messages: [
+        geminiMessage({
+          id: "shared-message-id",
+          timestamp: `${recentDate(1)}T12:00:00.000Z`,
+          input: 5,
+          output: 4,
+          total: 9,
+        }),
+      ],
+    }),
+  );
+
+  const result = await runCli(
+    ["--gemini", "--format", "json", "--output", outputPath],
+    {
+      GEMINI_CONFIG_DIR: geminiDir,
+    },
+  );
+
+  assert.equal(result.code, 0, result.stderr || result.stdout);
+
+  const payload = JSON.parse(readFileSync(outputPath, "utf8")) as {
+    providers: Array<{
+      daily: Array<{
+        date: string;
+        total: number;
+        input: number;
+        output: number;
+        breakdown: Array<{ name: string; tokens: { total: number } }>;
+      }>;
+    }>;
+  };
+
+  assert.deepEqual(
+    payload.providers[0]?.daily.map((day) => ({
+      date: day.date,
+      input: day.input,
+      output: day.output,
+      total: day.total,
+      model: day.breakdown[0]?.name,
+      modelTotal: day.breakdown[0]?.tokens.total,
+    })),
+    [
+      {
+        date: recentDate(1),
+        input: 9,
+        output: 7,
+        total: 16,
+        model: "gemini-3.1-pro-preview",
+        modelTotal: 16,
+      },
+    ],
+  );
+});
+
 test("Gemini CLI participates in multi-provider output order", async (t) => {
   const workspace = createTempWorkspace("gemini-default-order");
 

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -229,6 +229,69 @@ function openCodeMessage(options: {
   });
 }
 
+function geminiMessage(options: {
+  id?: string;
+  timestamp?: string;
+  type?: string;
+  model?: string;
+  input?: number;
+  output?: number;
+  cached?: number;
+  thoughts?: number;
+  tool?: number;
+  total?: number;
+}) {
+  const {
+    id = "gemini-msg-1",
+    timestamp = recentIso(),
+    type = "gemini",
+    model = "gemini-3.1-pro-preview",
+    input = 10,
+    output = 5,
+    cached = 0,
+    thoughts = 0,
+    tool = 0,
+    total = input + output + thoughts + tool,
+  } = options;
+
+  return {
+    id,
+    timestamp,
+    type,
+    model,
+    content: "done",
+    tokens: {
+      input,
+      output,
+      cached,
+      thoughts,
+      tool,
+      total,
+    },
+  };
+}
+
+function geminiSession(options: {
+  sessionId?: string;
+  startTime?: string;
+  lastUpdated?: string;
+  messages: Array<Record<string, unknown>>;
+}) {
+  const {
+    sessionId = "gemini-session-1",
+    startTime = recentIso(),
+    lastUpdated = recentIso(),
+    messages,
+  } = options;
+
+  return JSON.stringify({
+    sessionId,
+    startTime,
+    lastUpdated,
+    messages,
+  });
+}
+
 function piSessionHeader(cwd = "/tmp") {
   return JSON.stringify({
     type: "session",
@@ -332,6 +395,8 @@ async function createOpenCodeDb(
 }
 
 async function runCli(args: string[], extraEnv: Record<string, string>) {
+  const isolatedHome = extraEnv.HOME ?? tmpdir();
+
   return await new Promise<{
     code: number | null;
     stdout: string;
@@ -340,6 +405,7 @@ async function runCli(args: string[], extraEnv: Record<string, string>) {
     const child = spawn(cliRuntime, [cliPath, ...args], {
       env: {
         ...process.env,
+        HOME: isolatedHome,
         ...extraEnv,
         FORCE_COLOR: "0",
         NODE_NO_WARNINGS: "1",
@@ -699,6 +765,256 @@ test("--pi only loads Pi Coding Agent and ignores oversized irrelevant session r
   assert.equal(payload.providers[0]?.daily[0]?.output, 7);
   assert.equal(payload.providers[0]?.daily[0]?.total, 21);
   assert.equal(payload.providers[0]?.daily[0]?.breakdown[0]?.name, "gpt-5.4");
+});
+
+test("--gemini only loads Gemini CLI and only reports Gemini availability", async (t) => {
+  const workspace = createTempWorkspace("gemini-only");
+
+  t.after(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  const geminiDir = join(workspace, "gemini");
+  const outputPath = join(workspace, "out.json");
+
+  writeJsonFile(
+    join(geminiDir, "tmp", "project-a", "chats", "session-1.json"),
+    geminiSession({
+      messages: [
+        {
+          id: "user-1",
+          timestamp: `${recentDate(1)}T10:00:00.000Z`,
+          type: "user",
+          content: [{ text: "hello" }],
+        },
+        geminiMessage({
+          id: "gemini-1",
+          timestamp: `${recentDate(1)}T10:01:00.000Z`,
+          input: 12,
+          output: 8,
+          total: 20,
+        }),
+      ],
+    }),
+  );
+
+  const result = await runCli(
+    ["--gemini", "--format", "json", "--output", outputPath],
+    {
+      GEMINI_CONFIG_DIR: geminiDir,
+    },
+  );
+
+  assert.equal(result.code, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /Gemini CLI found/);
+  assert.doesNotMatch(result.stdout, /Claude code/);
+  assert.doesNotMatch(result.stdout, /Codex/);
+  assert.doesNotMatch(result.stdout, /Open Code/);
+  assert.doesNotMatch(result.stdout, /Pi Coding Agent/);
+
+  const payload = JSON.parse(readFileSync(outputPath, "utf8")) as {
+    providers: Array<{ provider: string; daily: Array<{ total: number }> }>;
+  };
+
+  assert.deepEqual(
+    payload.providers.map((provider) => provider.provider),
+    ["gemini"],
+  );
+  assert.equal(payload.providers[0]?.daily[0]?.total, 20);
+});
+
+test("Gemini recomputes totals from cache/thoughts/tool tokens and deduplicates session snapshots", async (t) => {
+  const workspace = createTempWorkspace("gemini-dedupe");
+
+  t.after(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  const geminiDir = join(workspace, "gemini");
+  const outputPath = join(workspace, "out.json");
+  const duplicateMessage = geminiMessage({
+    id: "gemini-dup-1",
+    timestamp: `${recentDate(2)}T09:00:00.000Z`,
+    model: "gemini-3.1-pro-preview-20260101",
+    input: 10,
+    output: 5,
+    cached: 3,
+    thoughts: 4,
+    tool: 2,
+    total: 21,
+  });
+
+  writeJsonFile(
+    join(geminiDir, "tmp", "project-a", "chats", "session-1.json"),
+    geminiSession({
+      sessionId: "gemini-session-dup",
+      lastUpdated: `${recentDate(2)}T09:10:00.000Z`,
+      messages: [
+        {
+          id: "info-1",
+          timestamp: `${recentDate(2)}T08:59:00.000Z`,
+          type: "info",
+          content: "update available",
+        },
+        duplicateMessage,
+      ],
+    }),
+  );
+  writeJsonFile(
+    join(geminiDir, "tmp", "project-b", "chats", "session-2.json"),
+    geminiSession({
+      sessionId: "gemini-session-dup",
+      lastUpdated: `${recentDate(0)}T11:00:00.000Z`,
+      messages: [
+        duplicateMessage,
+        {
+          id: "warning-1",
+          timestamp: `${recentDate(1)}T10:00:00.000Z`,
+          type: "warning",
+          content: "be careful",
+        },
+        geminiMessage({
+          id: "gemini-2",
+          timestamp: `${recentDate(0)}T11:01:00.000Z`,
+          model: "gemini-2.5-flash",
+          input: 7,
+          output: 1,
+          cached: 1,
+          thoughts: 0,
+          tool: 0,
+          total: 8,
+        }),
+      ],
+    }),
+  );
+
+  const result = await runCli(
+    ["--gemini", "--format", "json", "--output", outputPath],
+    {
+      GEMINI_CONFIG_DIR: geminiDir,
+    },
+  );
+
+  assert.equal(result.code, 0, result.stderr || result.stdout);
+
+  const payload = JSON.parse(readFileSync(outputPath, "utf8")) as {
+    providers: Array<{
+      provider: string;
+      daily: Array<{
+        date: string;
+        input: number;
+        output: number;
+        total: number;
+        breakdown: Array<{
+          name: string;
+          tokens: {
+            input: number;
+            output: number;
+            cache: { input: number; output: number };
+            total: number;
+          };
+        }>;
+      }>;
+      insights?: {
+        mostUsedModel?: { name: string };
+        recentMostUsedModel?: { name: string };
+      };
+    }>;
+  };
+
+  assert.deepEqual(
+    payload.providers[0]?.daily.map((day) => ({
+      date: day.date,
+      input: day.input,
+      output: day.output,
+      total: day.total,
+      model: day.breakdown[0]?.name,
+      cacheInput: day.breakdown[0]?.tokens.cache.input,
+    })),
+    [
+      {
+        date: recentDate(2),
+        input: 13,
+        output: 11,
+        total: 24,
+        model: "gemini-3.1-pro-preview",
+        cacheInput: 3,
+      },
+      {
+        date: recentDate(0),
+        input: 8,
+        output: 1,
+        total: 9,
+        model: "gemini-2.5-flash",
+        cacheInput: 1,
+      },
+    ],
+  );
+  assert.equal(
+    payload.providers[0]?.insights?.mostUsedModel?.name,
+    "gemini-3.1-pro-preview",
+  );
+  assert.equal(
+    payload.providers[0]?.insights?.recentMostUsedModel?.name,
+    "gemini-3.1-pro-preview",
+  );
+});
+
+test("Gemini CLI participates in multi-provider output order", async (t) => {
+  const workspace = createTempWorkspace("gemini-default-order");
+
+  t.after(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  const geminiDir = join(workspace, "gemini");
+  const piAgentDir = join(workspace, "pi-agent");
+  const outputPath = join(workspace, "out.json");
+
+  writeJsonFile(
+    join(geminiDir, "tmp", "project-a", "chats", "session-1.json"),
+    geminiSession({
+      messages: [
+        geminiMessage({
+          id: "gemini-default-1",
+          timestamp: `${recentDate(1)}T13:00:00.000Z`,
+          input: 3,
+          output: 2,
+          total: 5,
+        }),
+      ],
+    }),
+  );
+  writeJsonlFile(join(piAgentDir, "sessions", "session.jsonl"), [
+    piSessionHeader(workspace),
+    piAssistantMessage({
+      timestamp: `${recentDate(0)}T14:00:00.000Z`,
+      input: 4,
+      output: 3,
+      totalTokens: 7,
+    }),
+  ]);
+
+  const result = await runCli(
+    ["--gemini", "--pi", "--format", "json", "--output", outputPath],
+    {
+      GEMINI_CONFIG_DIR: geminiDir,
+      PI_CODING_AGENT_DIR: piAgentDir,
+    },
+  );
+
+  assert.equal(result.code, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /Gemini CLI found/);
+  assert.match(result.stdout, /Pi Coding Agent found/);
+
+  const payload = JSON.parse(readFileSync(outputPath, "utf8")) as {
+    providers: Array<{ provider: string }>;
+  };
+
+  assert.deepEqual(
+    payload.providers.map((provider) => provider.provider),
+    ["gemini", "pi"],
+  );
 });
 
 test("Codex skips oversized irrelevant records and still counts token usage", async (t) => {
@@ -1284,5 +1600,59 @@ test("OpenCode fails clearly on oversized SQLite message payloads", async (t) =>
   assert.notEqual(result.code, 0);
   assert.match(result.stderr, /JSON payload exceeds 256 bytes/);
   assert.match(result.stderr, /opencode\.db:message:msg-db-oversized/);
+  assert.match(result.stderr, /SLOPMETER_MAX_JSONL_RECORD_BYTES/);
+});
+
+test("Gemini fails clearly on oversized session JSON documents", async (t) => {
+  const workspace = createTempWorkspace("gemini-oversized");
+
+  t.after(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  const geminiDir = join(workspace, "gemini");
+  const oversizedFile = join(
+    geminiDir,
+    "tmp",
+    "project-a",
+    "chats",
+    "session-oversized.json",
+  );
+
+  writeJsonFile(
+    oversizedFile,
+    JSON.stringify({
+      sessionId: "gemini-oversized",
+      startTime: recentIso(),
+      lastUpdated: recentIso(),
+      messages: [
+        {
+          ...geminiMessage({
+            id: "gemini-oversized-1",
+            timestamp: `${recentDate(0)}T15:00:00.000Z`,
+            input: 1,
+            output: 1,
+            total: 2,
+          }),
+          padding: "x".repeat(1024),
+        },
+      ],
+    }),
+  );
+
+  const result = await runCli(
+    ["--gemini", "--format", "json", "--output", join(workspace, "out.json")],
+    {
+      GEMINI_CONFIG_DIR: geminiDir,
+      SLOPMETER_MAX_JSONL_RECORD_BYTES: "256",
+    },
+  );
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /Gemini session JSON document exceeds 256 bytes/);
+  assert.match(
+    result.stderr,
+    new RegExp(oversizedFile.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+  );
   assert.match(result.stderr, /SLOPMETER_MAX_JSONL_RECORD_BYTES/);
 });


### PR DESCRIPTION
## Summary

This adds full Gemini CLI support to `slopmeter`.

It introduces a new `--gemini` provider that reads Gemini session data from `~/.gemini/tmp/**/chats/session-*.json` (or `$GEMINI_CONFIG_DIR`) and renders it like the existing providers in PNG, SVG, and JSON output.

## What Changed

- added a new Gemini provider loader
- added `--gemini` to the CLI, provider lists, and availability output
- added a dedicated Gemini heatmap theme
- included Gemini in merged provider rendering and JSON export types
- documented Gemini data locations and usage in both READMEs
- added test coverage for Gemini-only runs, token aggregation, duplicate session snapshot deduplication, multi-provider ordering, and oversized-session failures

## Gemini Token Semantics

Gemini session logs expose `input`, `output`, `cached`, `thoughts`, and `tool` counters.
To keep Gemini output consistent with `slopmeter`'s existing token model, this PR maps them as follows:

- `cache.input = cached`
- `cache.output = 0`
- `input = input + cached`
- `output = output + thoughts + tool`
- `total = input + output`

The raw Gemini `tokens.total` value is not used directly.

## Notes

Real Gemini data may contain repeated session snapshots across multiple `session-*.json` files, so the loader deduplicates usage by `message.id` to avoid double counting.

## Validation

- `npx -y bun@1.3.3 run --cwd packages/cli test`
- `npx -y bun@1.3.3 run check`
- manual smoke test on real `~/.gemini` data by generating JSON and PNG output

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Gemini CLI support to `slopmeter` with a new `--gemini` provider, enabling PNG/SVG/JSON output and inclusion in merged views.

- **New Features**
  - Added `--gemini` with a loader for `~/.gemini/tmp/**/chats/session-*.json` or `$GEMINI_CONFIG_DIR`.
  - Mapped tokens: `cache.input = cached`, `input += cached`, `output += thoughts + tool`; ignore raw `tokens.total`.
  - Deduped repeated snapshots within a session (scoped by `sessionId` and message data).
  - Added a Gemini heatmap theme; updated “All” title; JSON export version set to 2026-03-13; types include Gemini.
  - Clear errors for oversized session JSON; updated docs and tests for Gemini-only runs, aggregation, ordering, and failures.

- **Migration**
  - Run `slopmeter --gemini` (or `--all`). Set `$GEMINI_CONFIG_DIR` if data isn’t in `~/.gemini`.

<sup>Written for commit 6a98607d15e3bce62b2d29158779bc4efa88ff98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

