### PR TITLE
Show cached usage details in heatmap headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,12 @@ slopmeter --pi
 
 - Monday-first contribution-style heatmap for the last year.
 - Top metrics per provider:
+  - `LAST 30 DAYS`
   - `INPUT TOKENS`
+  - cache reads are shown under `INPUT TOKENS` when available
   - `OUTPUT TOKENS`
+  - cache writes are shown under `OUTPUT TOKENS` when available
   - `TOTAL TOKENS` (includes cache tokens)
-  - cache reads and cache writes are shown under `TOTAL TOKENS` when available
 - Bottom metrics per provider:
   - `MOST USED MODEL` (with total tokens)
   - `RECENT USE (LAST 30 DAYS)` (with total tokens)

--- a/packages/cli/src/graph.ts
+++ b/packages/cli/src/graph.ts
@@ -272,17 +272,6 @@ function formatTokenTotalDetailed(value: number) {
   return numberFormatter.format(value);
 }
 
-function formatPercent(part: number, whole: number) {
-  if (whole <= 0) {
-    return "0%";
-  }
-
-  const percent = (part / whole) * 100;
-  const precision = percent >= 10 ? 1 : 2;
-
-  return `${percent.toFixed(precision)}%`;
-}
-
 function truncateText(value: string, maxLength: number) {
   if (value.length <= maxLength) {
     return value;
@@ -389,9 +378,9 @@ function getSectionLayout(weekCount: number) {
   const rightPadding = 20;
   const headerCaptionY = 0;
   const headerValueY = headerCaptionY + metricCaptionFontSize + captionValueGap;
-  // Reserve room for optional cache helper lines under total tokens.
+  // Reserve room for optional cache helper lines under input/output.
   const topMetricHeight =
-    headerValueY + metricValueFontSize + metricCaptionFontSize * 2 + 12;
+    headerValueY + metricValueFontSize + metricCaptionFontSize + 6;
   const topPadding = Math.max(providerTitleFontSize, topMetricHeight) + 20;
   const monthHeaderHeight = 20;
   const titleY = 0;
@@ -486,12 +475,10 @@ function drawHeatmapSection(
   const totalTokensLabel = formatTokenTotal(totalTokens);
   const totalInputLabel = formatTokenTotal(totalInputTokens);
   const totalOutputLabel = formatTokenTotal(totalOutputTokens);
-  const totalCachedOutputLabel = formatTokenTotal(totalCachedOutputTokens);
-  const totalCachedInputLabel = formatTokenTotal(totalCachedInputTokens);
   const longestStreak = insights?.streaks.longest ?? 0;
   const currentStreak = insights?.streaks.current ?? 0;
-  const cachedInputHelperLabel = `cache read ${formatTokenTotalDetailed(totalCachedInputTokens)} (${formatPercent(totalCachedInputTokens, totalTokens)} total)`;
-  const cachedOutputHelperLabel = `cache write ${formatTokenTotalDetailed(totalCachedOutputTokens)} (${formatPercent(totalCachedOutputTokens, totalTokens)} total)`;
+  const cachedInputHelperLabel = `cache read ${formatTokenTotalDetailed(totalCachedInputTokens)}`;
+  const cachedOutputHelperLabel = `cache write ${formatTokenTotalDetailed(totalCachedOutputTokens)}`;
 
   if (titleCaption) {
     svg = svg.text(
@@ -562,6 +549,21 @@ function drawHeatmapSection(
     totalInputLabel,
   );
 
+  if (totalCachedInputTokens > 0) {
+    svg = svg.text(
+      {
+        x: headerInputX,
+        y: y + layout.headerValueY + metricValueFontSize + 6,
+        fill: palette.muted,
+        "font-size": metricCaptionFontSize,
+        "text-anchor": "end",
+        "dominant-baseline": "hanging",
+        "font-family": fontFamily,
+      },
+      cachedInputHelperLabel,
+    );
+  }
+
   svg = svg.text(
     {
       x: headerOutputX,
@@ -590,6 +592,21 @@ function drawHeatmapSection(
     totalOutputLabel,
   );
 
+  if (totalCachedOutputTokens > 0) {
+    svg = svg.text(
+      {
+        x: headerOutputX,
+        y: y + layout.headerValueY + metricValueFontSize + 6,
+        fill: palette.muted,
+        "font-size": metricCaptionFontSize,
+        "text-anchor": "end",
+        "dominant-baseline": "hanging",
+        "font-family": fontFamily,
+      },
+      cachedOutputHelperLabel,
+    );
+  }
+
   svg = svg.text(
     {
       x: rightEdge,
@@ -617,36 +634,6 @@ function drawHeatmapSection(
     },
     totalTokensLabel,
   );
-
-  if (totalCachedInputTokens > 0) {
-    svg = svg.text(
-      {
-        x: rightEdge,
-        y: y + layout.headerValueY + metricValueFontSize + 6,
-        fill: palette.muted,
-        "font-size": metricCaptionFontSize,
-        "text-anchor": "end",
-        "dominant-baseline": "hanging",
-        "font-family": fontFamily,
-      },
-      cachedInputHelperLabel,
-    );
-  }
-
-  if (totalCachedOutputTokens > 0) {
-    svg = svg.text(
-      {
-        x: rightEdge,
-        y: y + layout.headerValueY + metricValueFontSize + metricCaptionFontSize + 10,
-        fill: palette.muted,
-        "font-size": metricCaptionFontSize,
-        "text-anchor": "end",
-        "dominant-baseline": "hanging",
-        "font-family": fontFamily,
-      },
-      cachedOutputHelperLabel,
-    );
-  }
 
   for (let i = 0; i < 7; i += 1) {
     const dayY =

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -898,9 +898,9 @@ test("Heatmap header shows cached metrics when cache tokens are present", () => 
 
   assert.match(svg, /INPUT TOKENS/);
   assert.match(svg, />120</);
-  assert.match(svg, /TOTAL TOKENS/);
-  assert.match(svg, /cache read 80 \(50\.0% total\)/);
-  assert.match(svg, /cache write 12 \(7\.5% total\)/);
+  assert.match(svg, /cache read 80/);
+  assert.match(svg, /OUTPUT TOKENS/);
+  assert.match(svg, /cache write 12/);
 });
 
 test("Claude falls back to stats-cache.json for older layouts without double counting project logs", async (t) => {


### PR DESCRIPTION
## Summary

Show cached usage details in the heatmap header without changing the underlying usage aggregation.

## What changed

- keep the main `INPUT TOKENS`, `OUTPUT TOKENS`, and `TOTAL TOKENS` values as the existing totals
- show cache reads as helper text under `INPUT TOKENS` when present
- show cache writes as helper text under `OUTPUT TOKENS` when present
- avoid percentage math for cache helpers so providers like Cursor do not imply invalid comparisons
- reserve enough header space so the extra helper lines do not crowd the section layout
- add focused rendering coverage for the cached helper text
- update the README to describe the new header presentation

## Why

Cached usage is already tracked in the report data, but it was not surfaced in the rendered heatmap. Showing cache reads and writes directly in the header makes the graph more informative while preserving the existing top-line totals.

## Before / After example

Examples below are from one local render against real usage data.

### Claude CLI (WSL)

Before:

```text
INPUT TOKENS  460M
OUTPUT TOKENS 16.3M
TOTAL TOKENS  476M
```

After:

```text
INPUT TOKENS  460M
cache read    459.8M
OUTPUT TOKENS 16.3M
cache write   15.47M
TOTAL TOKENS  476M
```

### Cursor (Windows)

Before:

```text
INPUT TOKENS  997M
OUTPUT TOKENS 9.14M
TOTAL TOKENS  1.01B
```

After:

```text
INPUT TOKENS  997M
cache read    914.4M
OUTPUT TOKENS 9.14M
cache write   48.2M
TOTAL TOKENS  1.01B
```

## Testing

- added focused SVG rendering coverage for cached helper text
- ran targeted local renderer checks against real report data

## Notes

This PR is intentionally scoped to the cached usage display only.