### PR TITLE
feat: add Amp (ampcode) as a usage provider

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -29,6 +29,7 @@ interface CliArgValues {
   help: boolean;
   dark: boolean;
   all: boolean;
+  amp: boolean;
   claude: boolean;
   codex: boolean;
   cursor: boolean;
@@ -47,10 +48,11 @@ const HELP_TEXT = `slopmeter
 Generate rolling 1-year usage heatmap image(s) (today is the latest day).
 
 Usage:
-  slopmeter [--all] [--claude] [--codex] [--cursor] [--gemini] [--opencode] [--pi] [--dark] [--format png|svg|json] [--output ./heatmap-last-year.png]
+  slopmeter [--all] [--amp] [--claude] [--codex] [--cursor] [--gemini] [--opencode] [--pi] [--dark] [--format png|svg|json] [--output ./heatmap-last-year.png]
 
 Options:
   --all                       Render one merged graph for all providers
+  --amp                       Render Amp graph
   --claude                    Render Claude Code graph
   --codex                     Render Codex graph
   --cursor                    Render Cursor graph
@@ -76,6 +78,7 @@ function validateArgs(values: unknown): asserts values is CliArgValues {
       help: ow.boolean,
       dark: ow.boolean,
       all: ow.boolean,
+      amp: ow.boolean,
       claude: ow.boolean,
       codex: ow.boolean,
       cursor: ow.boolean,
@@ -181,7 +184,7 @@ function getRequestedProviders(values: CliArgValues) {
 }
 
 function getMergedNoDataMessage() {
-  return "No usage data found for Claude Code, Codex, Cursor, Gemini CLI, Open Code, or Pi Coding Agent.";
+  return "No usage data found for Amp, Claude Code, Codex, Cursor, Gemini CLI, Open Code, or Pi Coding Agent.";
 }
 
 function getRequestedMissingProvidersMessage(missing: ProviderId[]) {
@@ -322,6 +325,7 @@ async function main() {
       help: { type: "boolean", short: "h", default: false },
       dark: { type: "boolean", default: false },
       all: { type: "boolean", default: false },
+      amp: { type: "boolean", default: false },
       claude: { type: "boolean", default: false },
       codex: { type: "boolean", default: false },
       cursor: { type: "boolean", default: false },

--- a/packages/cli/src/graph.ts
+++ b/packages/cli/src/graph.ts
@@ -79,6 +79,25 @@ interface SurfacePalette {
 }
 
 export const heatmapThemes: Record<HeatmapThemeId, HeatmapTheme> = {
+  amp: {
+    title: "Amp",
+    colors: {
+      light: [
+        "#ecfeff", // cyan-50
+        "#a5f3fc", // cyan-200
+        "#67e8f9", // cyan-300
+        "#06b6d4", // cyan-500
+        "#0e7490", // cyan-700
+      ],
+      dark: [
+        "#083344", // cyan-950
+        "#155e75", // cyan-800
+        "#0891b2", // cyan-600
+        "#22d3ee", // cyan-400
+        "#a5f3fc", // cyan-200
+      ],
+    },
+  },
   claude: {
     title: "Claude Code",
     colors: {
@@ -195,7 +214,7 @@ export const heatmapThemes: Record<HeatmapThemeId, HeatmapTheme> = {
   },
   all: {
     title:
-      "Claude Code / Codex / Cursor / Gemini CLI / Open Code / Pi Coding Agent",
+      "Amp / Claude Code / Codex / Cursor / Gemini CLI / Open Code / Pi Coding Agent",
     titleCaption: "Total usage from",
     colors: {
       light: [

--- a/packages/cli/src/interfaces.ts
+++ b/packages/cli/src/interfaces.ts
@@ -1,4 +1,5 @@
 export type UsageProviderId =
+  | "amp"
   | "claude"
   | "codex"
   | "cursor"

--- a/packages/cli/src/lib/amp.ts
+++ b/packages/cli/src/lib/amp.ts
@@ -35,6 +35,7 @@ interface AmpMessageUsage {
 interface AmpMessage {
   role?: string;
   usage?: AmpMessageUsage;
+  meta?: { sentAt?: number };
 }
 
 interface AmpThread {
@@ -102,18 +103,26 @@ async function processAmpFile(
     return { totals, modelTotals, recentModelTotals };
   }
 
-  if (!thread.created || !thread.messages) {
+  if (!thread.messages) {
     return { totals, modelTotals, recentModelTotals };
   }
 
-  const threadDate = new Date(thread.created);
-
-  if (threadDate < start || threadDate > end) {
-    return { totals, modelTotals, recentModelTotals };
-  }
+  const threadDate = thread.created ? new Date(thread.created) : null;
+  let lastUserTimestamp: Date | null = null;
 
   for (const message of thread.messages) {
+    if (message.role === "user" && message.meta?.sentAt) {
+      lastUserTimestamp = new Date(message.meta.sentAt);
+      continue;
+    }
+
     if (message.role !== "assistant" || !message.usage) {
+      continue;
+    }
+
+    const date = lastUserTimestamp ?? threadDate;
+
+    if (!date || date < start || date > end) {
       continue;
     }
 
@@ -127,7 +136,7 @@ async function processAmpFile(
       ? normalizeModelName(message.usage.model)
       : undefined;
 
-    addDailyTokenTotals(totals, threadDate, tokenTotals, modelName);
+    addDailyTokenTotals(totals, date, tokenTotals, modelName);
 
     if (!modelName) {
       continue;
@@ -135,7 +144,7 @@ async function processAmpFile(
 
     addModelTokenTotals(modelTotals, modelName, tokenTotals);
 
-    if (threadDate >= recentStart) {
+    if (date >= recentStart) {
       addModelTokenTotals(recentModelTotals, modelName, tokenTotals);
     }
   }

--- a/packages/cli/src/lib/amp.ts
+++ b/packages/cli/src/lib/amp.ts
@@ -1,0 +1,174 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import type { UsageSummary } from "../interfaces";
+import {
+  DEFAULT_FILE_PROCESS_CONCURRENCY,
+  FILE_PROCESS_CONCURRENCY_ENV,
+  type DailyTotalsByDate,
+  type DailyTokenTotals,
+  type ModelTokenTotals,
+  addDailyTokenTotals,
+  addModelTokenTotals,
+  createUsageSummary,
+  getPositiveIntegerEnv,
+  getRecentWindowStart,
+  listFilesRecursive,
+  mergeDailyTotalsByDate,
+  mergeModelTotals,
+  normalizeModelName,
+  readJsonDocument,
+  runWithConcurrency,
+} from "./utils";
+
+const AMP_HOME_ENV = "AMP_DATA_DIR";
+
+interface AmpMessageUsage {
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+  totalInputTokens?: number;
+}
+
+interface AmpMessage {
+  role?: string;
+  usage?: AmpMessageUsage;
+}
+
+interface AmpThread {
+  id?: string;
+  created?: number;
+  messages?: AmpMessage[];
+}
+
+function getAmpDataDir() {
+  const envDir = process.env[AMP_HOME_ENV]?.trim();
+
+  if (envDir) {
+    return resolve(envDir);
+  }
+
+  const xdgDataHome =
+    process.env.XDG_DATA_HOME?.trim() || join(homedir(), ".local", "share");
+
+  return join(xdgDataHome, "amp");
+}
+
+async function getAmpFiles() {
+  const dataDir = getAmpDataDir();
+
+  return listFilesRecursive(join(dataDir, "threads"), ".json");
+}
+
+export function isAmpAvailable() {
+  return existsSync(join(getAmpDataDir(), "threads"));
+}
+
+function createAmpTokenTotals(usage: AmpMessageUsage): DailyTokenTotals {
+  const cacheReadInput = usage.cacheReadInputTokens ?? 0;
+  const cacheCreationInput = usage.cacheCreationInputTokens ?? 0;
+  const input = (usage.inputTokens ?? 0) + cacheReadInput;
+  const output = (usage.outputTokens ?? 0) + cacheCreationInput;
+
+  return {
+    input,
+    output,
+    cache: { input: cacheReadInput, output: cacheCreationInput },
+    total: input + output,
+  };
+}
+
+async function processAmpFile(
+  filePath: string,
+  start: Date,
+  end: Date,
+): Promise<{
+  totals: DailyTotalsByDate;
+  modelTotals: Map<string, ModelTokenTotals>;
+  recentModelTotals: Map<string, ModelTokenTotals>;
+}> {
+  const totals: DailyTotalsByDate = new Map();
+  const recentStart = getRecentWindowStart(end, 30);
+  const modelTotals = new Map<string, ModelTokenTotals>();
+  const recentModelTotals = new Map<string, ModelTokenTotals>();
+
+  let thread: AmpThread;
+
+  try {
+    thread = await readJsonDocument<AmpThread>(filePath);
+  } catch {
+    return { totals, modelTotals, recentModelTotals };
+  }
+
+  if (!thread.created || !thread.messages) {
+    return { totals, modelTotals, recentModelTotals };
+  }
+
+  const threadDate = new Date(thread.created);
+
+  if (threadDate < start || threadDate > end) {
+    return { totals, modelTotals, recentModelTotals };
+  }
+
+  for (const message of thread.messages) {
+    if (message.role !== "assistant" || !message.usage) {
+      continue;
+    }
+
+    const tokenTotals = createAmpTokenTotals(message.usage);
+
+    if (tokenTotals.total <= 0) {
+      continue;
+    }
+
+    const modelName = message.usage.model
+      ? normalizeModelName(message.usage.model)
+      : undefined;
+
+    addDailyTokenTotals(totals, threadDate, tokenTotals, modelName);
+
+    if (!modelName) {
+      continue;
+    }
+
+    addModelTokenTotals(modelTotals, modelName, tokenTotals);
+
+    if (threadDate >= recentStart) {
+      addModelTokenTotals(recentModelTotals, modelName, tokenTotals);
+    }
+  }
+
+  return { totals, modelTotals, recentModelTotals };
+}
+
+export async function loadAmpRows(
+  start: Date,
+  end: Date,
+): Promise<UsageSummary> {
+  const files = await getAmpFiles();
+  const totals: DailyTotalsByDate = new Map();
+  const modelTotals = new Map<string, ModelTokenTotals>();
+  const recentModelTotals = new Map<string, ModelTokenTotals>();
+  const fileConcurrency = getPositiveIntegerEnv(
+    FILE_PROCESS_CONCURRENCY_ENV,
+    DEFAULT_FILE_PROCESS_CONCURRENCY,
+  );
+
+  const results = new Array<Awaited<ReturnType<typeof processAmpFile>>>(
+    files.length,
+  );
+
+  await runWithConcurrency(files, fileConcurrency, async (file, index) => {
+    results[index] = await processAmpFile(file, start, end);
+  });
+
+  for (const result of results) {
+    mergeDailyTotalsByDate(totals, result.totals);
+    mergeModelTotals(modelTotals, result.modelTotals);
+    mergeModelTotals(recentModelTotals, result.recentModelTotals);
+  }
+
+  return createUsageSummary("amp", totals, modelTotals, recentModelTotals, end);
+}

--- a/packages/cli/src/lib/interfaces.ts
+++ b/packages/cli/src/lib/interfaces.ts
@@ -1,4 +1,5 @@
 export type ProviderId =
+  | "amp"
   | "claude"
   | "codex"
   | "cursor"
@@ -7,6 +8,7 @@ export type ProviderId =
   | "pi";
 
 export const providerIds: ProviderId[] = [
+  "amp",
   "claude",
   "codex",
   "cursor",
@@ -18,6 +20,7 @@ export const providerIds: ProviderId[] = [
 export const defaultProviderIds: ProviderId[] = ["claude", "codex", "cursor"];
 
 export const providerStatusLabel: Record<ProviderId, string> = {
+  amp: "Amp",
   claude: "Claude code",
   codex: "Codex",
   cursor: "Cursor",

--- a/packages/cli/src/providers.ts
+++ b/packages/cli/src/providers.ts
@@ -1,4 +1,5 @@
 import type { UsageSummary } from "./interfaces";
+import { isAmpAvailable, loadAmpRows } from "./lib/amp";
 import { isClaudeAvailable, loadClaudeRows } from "./lib/claude-code";
 import { isCodexAvailable, loadCodexRows } from "./lib/codex";
 import { isCursorAvailable, loadCursorRows } from "./lib/cursor";
@@ -30,6 +31,7 @@ export type ProviderAvailability = Record<ProviderId, boolean>;
 
 function createEmptyProviderAvailability(): ProviderAvailability {
   return {
+    amp: false,
     claude: false,
     codex: false,
     cursor: false,
@@ -41,6 +43,8 @@ function createEmptyProviderAvailability(): ProviderAvailability {
 
 export async function isProviderAvailable(provider: ProviderId): Promise<boolean> {
   switch (provider) {
+    case "amp":
+      return isAmpAvailable();
     case "claude":
       return isClaudeAvailable();
     case "codex":
@@ -97,6 +101,7 @@ export async function aggregateUsage({
     ? requestedProviders
     : providerIds;
   const rowsByProvider: Record<ProviderId, UsageSummary | null> = {
+    amp: null,
     claude: null,
     codex: null,
     cursor: null,
@@ -110,6 +115,9 @@ export async function aggregateUsage({
     let summary: UsageSummary;
 
     switch (provider) {
+      case "amp":
+        summary = await loadAmpRows(start, end);
+        break;
       case "claude":
         summary = await loadClaudeRows(start, end);
         break;


### PR DESCRIPTION
Adds Amp support to slopmeter by reading thread JSON files from `~/.local/share/amp/threads/` and extracting token usage from assistant message payloads.

## Changes

- New provider: `packages/cli/src/lib/amp.ts` — parses Amp thread files for token usage (input, output, cache creation, cache read)
- Registers `amp` in the provider pipeline alongside existing tools
- Adds `--amp` CLI flag to render Amp-only heatmaps
- Adds cyan heatmap color theme for Amp
- Supports `AMP_DATA_DIR` and `XDG_DATA_HOME` env vars for custom data locations

## Testing

- All 16 existing tests pass
- Typecheck passes
- Manually verified with real Amp thread data (574 threads, 94 days of usage detected)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Amp (ampcode) as a usage provider and heatmap theme, enabling Amp-only and merged graphs. Reads token usage from assistant messages in Amp thread JSON files under `~/.local/share/amp/threads/`.

- **New Features**
  - Register `amp` provider and parse input/output/cache token usage.
  - Add `--amp` CLI flag and include Amp in `--all` graphs.
  - Add cyan "Amp" heatmap theme and support `AMP_DATA_DIR` / `XDG_DATA_HOME`.

- **Bug Fixes**
  - Bucket Amp usage by the preceding user `sentAt` timestamp; fall back to `thread.created` only when missing to distribute usage across days.

<sup>Written for commit 73632139f8e3e3039f9f4e89ffb150e3484d22c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

